### PR TITLE
🎨 Palette: Add Tooltip to theme toggle and role="alert" to error message

### DIFF
--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -22,7 +22,12 @@ import PredictionResults from "./PredictionResults";
 import { StatTile } from "./stat-tile";
 import { defaultTrendData, initialFormValues } from "./constants";
 import { FLAT_MODELS, ML_MODELS, TOWNS } from "../../lib/lists";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type {
   ApiResponse,
   FieldType,
@@ -55,7 +60,9 @@ const panelCard =
 export default function PredictionClient() {
   return (
     <I18nProvider>
-      <PredictionClientInner />
+      <TooltipProvider delayDuration={300}>
+        <PredictionClientInner />
+      </TooltipProvider>
     </I18nProvider>
   );
 }
@@ -315,7 +322,7 @@ function PredictionClientInner() {
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom" sideOffset={8}>
-                <p>{darkMode ? t("switch_to_light_mode") : t("switch_to_dark_mode")}</p>
+                {darkMode ? t("switch_to_light_mode") : t("switch_to_dark_mode")}
               </TooltipContent>
             </Tooltip>
           </div>

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -22,6 +22,7 @@ import PredictionResults from "./PredictionResults";
 import { StatTile } from "./stat-tile";
 import { defaultTrendData, initialFormValues } from "./constants";
 import { FLAT_MODELS, ML_MODELS, TOWNS } from "../../lib/lists";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type {
   ApiResponse,
   FieldType,
@@ -301,15 +302,22 @@ function PredictionClientInner() {
             >
               {t("switch_language")}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-sm"
-              aria-label={darkMode ? t("switch_to_light_mode") : t("switch_to_dark_mode")}
-              onClick={() => setDarkMode((value) => !value)}
-            >
-              {darkMode ? <Sun className="size-4" /> : <Moon className="size-4" />}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label={darkMode ? t("switch_to_light_mode") : t("switch_to_dark_mode")}
+                  onClick={() => setDarkMode((value) => !value)}
+                >
+                  {darkMode ? <Sun className="size-4" /> : <Moon className="size-4" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={8}>
+                <p>{darkMode ? t("switch_to_light_mode") : t("switch_to_dark_mode")}</p>
+              </TooltipContent>
+            </Tooltip>
           </div>
         </header>
 
@@ -369,7 +377,7 @@ function PredictionClientInner() {
                   </div>
                 )}
                 {error && !loading && (
-                  <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+                  <div role="alert" className="mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
                     {error}
                   </div>
                 )}


### PR DESCRIPTION
🎨 Palette: Improve accessibility and UX of theme toggle and error message

💡 What: Wrapped the light/dark mode switch in a Tooltip and added `role="alert"` to the error message container.
🎯 Why: Tooltips make icon-only buttons discoverable for sighted users (improving UX). The `role="alert"` ensures screen readers announce dynamic error messages immediately upon failure (improving a11y).
♿ Accessibility: Added `role="alert"` to dynamic error banner. Added tooltip for `aria-label` equivalent visual representation.

---
*PR created automatically by Jules for task [5888569608317662477](https://jules.google.com/task/5888569608317662477) started by @shenghaoc*