### PR TITLE
⚡ Bolt: Memoize form summary state and PredictionResults

### DIFF
--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -143,11 +143,19 @@ function PredictionClientInner() {
       const next = { ...prev, ...allValues };
       return next;
     });
-    setSummaryValues((prev) => ({
-      ml_model: allValues.ml_model ?? prev.ml_model,
-      town: allValues.town ?? prev.town,
-      lease_commence_date: allValues.lease_commence_date ?? prev.lease_commence_date,
-    }));
+    setSummaryValues((prev) => {
+      const ml_model = allValues.ml_model ?? prev.ml_model;
+      const town = allValues.town ?? prev.town;
+      const lease_commence_date = allValues.lease_commence_date ?? prev.lease_commence_date;
+      if (
+        ml_model === prev.ml_model &&
+        town === prev.town &&
+        lease_commence_date === prev.lease_commence_date
+      ) {
+        return prev;
+      }
+      return { ml_model, town, lease_commence_date };
+    });
   }, []);
 
   useEffect(() => {

--- a/components/prediction/PredictionResults.tsx
+++ b/components/prediction/PredictionResults.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import { useMemo, memo } from "react";
 import { Home, Layers, MapPin, TrendingDown, TrendingUp } from "lucide-react";
 import type { TFunction } from "../../lib/i18n";
 import type { SummaryValues, TrendPoint } from "./types";
@@ -39,7 +39,7 @@ type PredictionResultsProps = {
   loading?: boolean;
 };
 
-export default function PredictionResults({
+export default memo(function PredictionResults({
   output,
   summaryValues,
   t,
@@ -237,7 +237,7 @@ export default function PredictionResults({
       </Card>
     </section>
   );
-}
+});
 
 function StatChip({
   label,


### PR DESCRIPTION
💡 What: Prevent unnecessary state object creation in `PredictionClient` when the underlying fields used for `summaryValues` haven't changed, and wrap the expensive `PredictionResults` component in `React.memo`.
🎯 Why: Previously, typing in the `floor_area_sqm` field or changing unrelated select boxes created a new `summaryValues` object on every keystroke, which triggered re-renders in `PredictionResults` and all its child elements (including the chart), leading to a sluggish typing experience.
📊 Impact: Eliminates expensive UI re-renders on keystrokes/select updates in the form when no new summary is generated.
🔬 Measurement: Verify typing inside the `floor_area_sqm` text field is much more responsive and that the `PredictionResults` module does not re-render until `get_prediction` is clicked.

---
*PR created automatically by Jules for task [3924032256394249637](https://jules.google.com/task/3924032256394249637) started by @shenghaoc*