### PR TITLE
🛡️ Sentinel: [Medium] Add standard HTTP security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,37 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	reactStrictMode: true
+	reactStrictMode: true,
+	async headers() {
+		return [
+			{
+				source: '/(.*)',
+				headers: [
+					{
+						key: 'X-Content-Type-Options',
+						value: 'nosniff'
+					},
+					{
+						key: 'X-Frame-Options',
+						value: 'DENY'
+					},
+					{
+						key: 'X-XSS-Protection',
+						value: '1; mode=block'
+					},
+					{
+						key: 'Referrer-Policy',
+						value: 'strict-origin-when-cross-origin'
+					},
+					{
+						key: 'Strict-Transport-Security',
+						value: 'max-age=31536000; includeSubDomains'
+					}
+				]
+			}
+		];
+	}
 };
 
 export default nextConfig;
 
-import('@opennextjs/cloudflare').then(m => m.initOpenNextCloudflareForDev());
+import('@opennextjs/cloudflare').then((m) => m.initOpenNextCloudflareForDev());

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const nextConfig = {
 	async headers() {
 		return [
 			{
-				source: '/(.*)',
+				source: '/:path*',
 				headers: [
 					{
 						key: 'X-Content-Type-Options',
@@ -13,10 +13,6 @@ const nextConfig = {
 					{
 						key: 'X-Frame-Options',
 						value: 'DENY'
-					},
-					{
-						key: 'X-XSS-Protection',
-						value: '1; mode=block'
 					},
 					{
 						key: 'Referrer-Policy',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers, leaving the application more susceptible to common web vulnerabilities like MIME-sniffing and clickjacking.
🎯 Impact: Attackers could potentially sniff MIME types, embed the site in malicious iframes, or downgrade secure connections.
🔧 Fix: Added standard HTTP security headers to `next.config.js` via the `headers()` async function, applying them to all routes (`/(.*)`).
✅ Verification: Review the `next.config.js` file for the new headers or check network responses after deployment.

* Removed automatically generated `pnpm-lock.yaml` file to keep the change focused and under the required line limits.

---
*PR created automatically by Jules for task [9440578734983350902](https://jules.google.com/task/9440578734983350902) started by @shenghaoc*