### PR TITLE
🎨 Palette: Add keyboard accessibility to StatTile hint

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Unifying Focus States for Composite Input Components
 **Learning:** When dealing with composite inputs containing multiple interactive sub-elements (like an `Input` accompanied by an inline unit label/span), using `focus-within` on the parent container provides a unified and cohesive focus state. Applying focus states directly to inner children often results in conflicting border overlaps or partial highlighting.
 **Action:** When designing or refactoring composite form components in Tailwind CSS/Shadcn, apply focus, hover, and shadow states directly to a wrapping container using `focus-within:` classes, and remove default borders and outlines from the nested elements. This ensures visual consistency across the entire component block.
+
+## 2024-05-19 - Making Radix UI Tooltip Triggers Keyboard Accessible
+**Learning:** Radix UI `TooltipTrigger` components rely on their children to be natively focusable to trigger tooltips via keyboard navigation. If the `asChild` prop wraps a non-interactive element (like a generic `<div>`), keyboard users cannot access the tooltip content, leading to a critical accessibility failure.
+**Action:** Always ensure that elements wrapped by a `TooltipTrigger` are natively focusable. If wrapping a non-interactive element, explicitly add `tabIndex={0}` and apply clear `focus-visible` styles to provide proper keyboard navigation feedback.

--- a/components/prediction/stat-tile.tsx
+++ b/components/prediction/stat-tile.tsx
@@ -24,7 +24,7 @@ export function StatTile({ icon: Icon, label, value, hint, className }: StatTile
       className={cn(
         "group/tile flex items-center gap-3 rounded-xl border border-border/60 bg-card/90 p-4 shadow-sm transition-all duration-300",
         "hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-md hover:shadow-primary/5",
-        hint && "cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2",
+        hint && "cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         className,
       )}
     >

--- a/components/prediction/stat-tile.tsx
+++ b/components/prediction/stat-tile.tsx
@@ -20,10 +20,11 @@ type StatTileProps = {
 export function StatTile({ icon: Icon, label, value, hint, className }: StatTileProps) {
   const tile = (
     <div
+      tabIndex={hint ? 0 : undefined}
       className={cn(
         "group/tile flex items-center gap-3 rounded-xl border border-border/60 bg-card/90 p-4 shadow-sm transition-all duration-300",
         "hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-md hover:shadow-primary/5",
-        hint && "cursor-help",
+        hint && "cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2",
         className,
       )}
     >


### PR DESCRIPTION
💡 What: Added `tabIndex={hint ? 0 : undefined}` and `focus-visible` ring styling to the `StatTile` component when a hint is present.
🎯 Why: The Radix UI `TooltipTrigger` was wrapping a generic non-interactive `div`, which prevented keyboard users from focusing the tile and seeing the tooltip hint.
📸 Before/After: Before, keyboard users could not tab to the stat tiles. After, tabbing correctly focuses the stat tiles and displays a visible ring along with the tooltip content.
♿ Accessibility: Ensures full keyboard accessibility for the statistics tooltips.

---
*PR created automatically by Jules for task [8855794082890887558](https://jules.google.com/task/8855794082890887558) started by @shenghaoc*