### PR TITLE
feat: v5 design handoff — Combobox, NumberField, a11y improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,9 +4,8 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: var(--font-dm-sans), "Avenir Next", "SF Pro Text", "Helvetica Neue", "Segoe UI", Arial, sans-serif;
-  --font-heading: var(--font-lora), "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
-  --font-serif: var(--font-heading);
+  --font-sans: var(--font-source-sans), "Source Sans 3", "Source Sans Pro", "Helvetica Neue", "Segoe UI", Arial, sans-serif;
+  --font-heading: var(--font-source-sans), "Source Sans 3", "Source Sans Pro", "Helvetica Neue", "Segoe UI", Arial, sans-serif;
   --font-cjk: "PingFang SC", "Hiragino Sans GB", "Noto Sans CJK SC", "Microsoft YaHei", sans-serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -32,11 +31,11 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
+  --radius-sm: calc(var(--radius) * 0.5);
+  --radius-md: calc(var(--radius) * 1);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-xl: calc(var(--radius) * 1.33);
+  --radius-2xl: calc(var(--radius) * 1.67);
 }
 
 /* color-scheme follows html.dark so light-dark() tokens resolve correctly.
@@ -44,35 +43,47 @@
 :root {
   color-scheme: light;
 
-  --background: light-dark(#f2f3f8, #0c0f1d);
-  --foreground: light-dark(#0f172a, #f1f5f9);
-  --card: light-dark(#ffffff, #161929);
-  --card-foreground: light-dark(#0f172a, #f1f5f9);
-  --popover: light-dark(#ffffff, #161929);
-  --popover-foreground: light-dark(#0f172a, #f1f5f9);
+  --background: light-dark(#f4f5f7, #0f1117);
+  --foreground: light-dark(#1a1a2e, #e8eaf0);
+  --card: light-dark(#ffffff, #1a1c25);
+  --card-foreground: light-dark(#1a1a2e, #e8eaf0);
+  --popover: light-dark(#ffffff, #1a1c25);
+  --popover-foreground: light-dark(#1a1a2e, #e8eaf0);
   --primary: light-dark(#4f46e5, #818cf8);
   --primary-foreground: light-dark(#ffffff, #0f172a);
-  --secondary: light-dark(#f4f5fa, #111427);
+  --secondary: light-dark(#eef0f4, #1e2029);
   --secondary-foreground: light-dark(#475569, #94a3b8);
-  --muted: light-dark(#f4f5fa, #111427);
+  --muted: light-dark(#eef0f4, #1e2029);
   --muted-foreground: light-dark(#64748b, #94a3b8);
   --accent: light-dark(#eef2ff, rgba(129, 140, 248, 0.12));
   --accent-foreground: light-dark(#4338ca, #e0e7ff);
   --destructive: light-dark(#dc2626, #f87171);
   --destructive-foreground: light-dark(#ffffff, #2a0c0c);
-  --border: light-dark(#e2e8f0, #272b42);
-  --input: light-dark(#e2e8f0, #353a55);
+  --border: light-dark(#dde1e8, #2a2d3a);
+  --border-strong: light-dark(#cbd5e1, #353a55);
+  --input: light-dark(#dde1e8, #353a55);
   --ring: var(--primary);
   --chart-1: var(--primary);
   --chart-2: light-dark(#6366f1, #a5b4fc);
   --chart-3: light-dark(#8b5cf6, #c4b5fd);
   --chart-4: light-dark(#10b981, #4ade80);
   --chart-5: light-dark(#f59e0b, #fbbf24);
-  --radius: 0.625rem;
+  --radius: 6px;
+
+  /* v6 compact sizes */
+  --height-field: 32px;
+  --height-button: 32px;
+  --height-button-sm: 28px;
+  --height-icon-button: 32px;
+  --spacing-card-inner: 16px;
+  --shadow-focus: 0 0 0 2px color-mix(in oklab, var(--ring) 18%, transparent);
+  --shadow-button: none;
+  --shadow-button-hover: none;
 
   /* Pre-shadcn names kept for PriceTrendChart SVG + styles.css */
   --color-page: var(--background);
   --color-surface: var(--card);
+  --color-border: var(--border);
   --color-input-bg: var(--secondary);
   --color-text: var(--foreground);
   --color-text-secondary: var(--secondary-foreground);
@@ -94,24 +105,6 @@
   html,
   body {
     @apply min-h-screen bg-background font-sans text-foreground antialiased;
-    background-image:
-      radial-gradient(
-        ellipse 80% 50% at 50% -20%,
-        color-mix(in oklab, var(--primary) 12%, transparent),
-        transparent
-      ),
-      radial-gradient(
-        circle,
-        color-mix(in oklab, var(--primary) 10%, transparent) 1px,
-        transparent 1px
-      );
-    background-size:
-      100% 480px,
-      22px 22px;
-    background-position:
-      center top,
-      center center;
-    background-repeat: no-repeat, repeat;
   }
 
   button,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
-import { DM_Sans, Lora } from 'next/font/google';
+import { Source_Sans_3 } from 'next/font/google';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import {
@@ -11,17 +11,10 @@ import {
 	SITE_URL
 } from '../lib/site';
 
-const dmSans = DM_Sans({
+const sourceSans3 = Source_Sans_3({
 	subsets: ['latin'],
-	weight: ['400', '500', '600', '700', '800'],
-	variable: '--font-dm-sans',
-	display: 'swap'
-});
-
-const lora = Lora({
-	subsets: ['latin'],
-	weight: ['400', '500', '600', '700'],
-	variable: '--font-lora',
+	weight: ['300', '400', '500', '600', '700', '800', '900'],
+	variable: '--font-source-sans',
 	display: 'swap'
 });
 
@@ -68,7 +61,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
-		<html lang="en" className={`${dmSans.variable} ${lora.variable}`}>
+		<html lang="en" className={sourceSans3.variable}>
 			<body>
 				<TooltipProvider delayDuration={300}>{children}</TooltipProvider>
 				<Toaster richColors closeButton />

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -16,6 +16,7 @@
   "switch_language": "中文/English",
   "price_prediction": "Price\nPrediction",
   "intro_blurb": "Compare flat attributes, submit a scenario, and get a quick resale estimate with a 12-month trend view.",
+  "intro_caption": "Fast scenario testing for layout, lease, and town combinations.",
   "prediction_form": "Prediction Form",
   "ml_model": "ML Model",
   "select_ml_model": "Select ML Model",

--- a/app/locales/zh.json
+++ b/app/locales/zh.json
@@ -16,6 +16,7 @@
   "switch_language": "中文/English",
   "price_prediction": "价格\n预测",
   "intro_blurb": "比较房屋属性，提交一个情境，并快速查看估算转售价与过去12个月趋势。",
+  "intro_caption": "新加坡组屋转售价估算器 — 快速情境测试。",
   "prediction_form": "预测表单",
   "ml_model": "机器学习模型",
   "select_ml_model": "选择机器学习模型",

--- a/app/styles.css
+++ b/app/styles.css
@@ -81,10 +81,6 @@ html {
   to   { opacity: 1; transform: translateY(0); }
 }
 
-@keyframes fade-up-deep {
-  from { opacity: 0; transform: translateY(24px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
 
 @keyframes settle {
   0%   { transform: scale(0.96); opacity: 0.72; }
@@ -108,15 +104,6 @@ html {
   100% { transform: translateX(100%); }
 }
 
-@keyframes glow-pulse {
-  0%, 100% { box-shadow: 0 0 12px color-mix(in oklab, var(--primary) 20%, transparent); }
-  50%      { box-shadow: 0 0 28px color-mix(in oklab, var(--primary) 35%, transparent); }
-}
-
-@keyframes float {
-  0%, 100% { transform: translateY(0px); }
-  50%      { transform: translateY(-6px); }
-}
 
 @keyframes empty-float {
   0%, 100% { transform: translateY(0px) rotate(0deg); }
@@ -129,24 +116,6 @@ html {
   .animate-enter {
     opacity: 0;
     transform: translateY(6px);
-  }
-}
-
-/* ── Reduced motion ──────────────────────────────────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  .animate-fade-in,
-  .animate-fade-in-deep,
-  .animate-enter,
-  .animate-pulse,
-  .animate-settle,
-  .animate-stagger {
-    animation: none;
-    transition: none;
-    opacity: 1;
-    transform: none;
-  }
-  .animate-glow {
-    animation: none;
   }
 }
 
@@ -177,9 +146,6 @@ html {
   animation: fade-up 0.35s ease-out both;
 }
 
-.animate-fade-in-deep {
-  animation: fade-up-deep 0.5s ease-out both;
-}
 
 .animate-settle {
   animation: settle 0.55s ease;
@@ -189,23 +155,18 @@ html {
   animation: subtle-pulse 1.2s ease-in-out infinite;
 }
 
-.animate-glow {
-  animation: glow-pulse 2.4s ease-in-out infinite;
+/* ── Reduced motion ──────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-enter,
+  .animate-pulse,
+  .animate-settle {
+    animation: none;
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
 }
-
-/* Staggered entrance — add .animate-stagger to each child */
-.animate-stagger > * {
-  opacity: 0;
-  animation: fade-up 0.4s ease-out forwards;
-}
-.animate-stagger > *:nth-child(1) { animation-delay: 0.05s; }
-.animate-stagger > *:nth-child(2) { animation-delay: 0.12s; }
-.animate-stagger > *:nth-child(3) { animation-delay: 0.19s; }
-.animate-stagger > *:nth-child(4) { animation-delay: 0.26s; }
-.animate-stagger > *:nth-child(5) { animation-delay: 0.33s; }
-.animate-stagger > *:nth-child(6) { animation-delay: 0.40s; }
-
-/* Shimmer skeleton */
 .animate-shimmer {
   background: linear-gradient(
     110deg,

--- a/app/styles.css
+++ b/app/styles.css
@@ -296,3 +296,23 @@ input[data-no-spinner="true"]::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+/* ── v5: Focus-visible only (React Aria pattern) ──────────────────────── */
+:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ── v5: Combobox listbox scrollbar ───────────────────────────────────── */
+[role="listbox"]::-webkit-scrollbar {
+  width: 4px;
+}
+[role="listbox"]::-webkit-scrollbar-thumb {
+  background: color-mix(in oklab, var(--foreground) 15%, transparent);
+  border-radius: 9999px;
+}

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -315,7 +315,7 @@ function PredictionClientInner() {
         }
       }
     },
-    [t],
+    [t, lang, announce],
   );
 
   // Keyboard shortcuts: Ctrl/Cmd+Enter to submit, Escape to reset

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -83,7 +83,6 @@ function PredictionClientInner() {
   });
   const hasRestoredRef = useRef(false);
   const resultsRef = useRef<HTMLDivElement>(null);
-  const formRef = useRef<HTMLFormElement>(null);
   const liveRef = useRef<HTMLDivElement>(null);
   const requestControllerRef = useRef<AbortController | null>(null);
   const latestFormRef = useRef(formValues);
@@ -329,7 +328,7 @@ function PredictionClientInner() {
       if (
         e.key === "Escape" &&
         !document.querySelector('[role="listbox"]') &&
-        formRef.current?.contains(document.activeElement)
+        document.activeElement?.closest("form")
       ) {
         handleReset();
         announce(lang === "zh" ? "表单已重置" : "Form reset");

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -13,6 +13,8 @@ import { toast } from "sonner";
 import { I18nProvider, useI18n } from "../../lib/i18n";
 import { Temporal } from "../../lib/temporal";
 import {
+  MAX_FLOOR_AREA_SQM,
+  MIN_FLOOR_AREA_SQM,
   STORAGE_KEYS,
   type PredictionRequestBody,
   serializeLeaseCommenceDate,
@@ -187,7 +189,7 @@ function PredictionClientInner() {
       if (
         ml_model === prev.ml_model &&
         town === prev.town &&
-        lease_commence_date === prev.lease_commence_date
+        lease_commence_date.year === prev.lease_commence_date.year
       ) {
         return prev;
       }
@@ -271,12 +273,16 @@ function PredictionClientInner() {
       setError(null);
       setOutput(0);
       setTrendData(defaultTrendData);
+      const floorArea =
+        typeof values.floor_area_sqm === "number"
+          ? Math.max(MIN_FLOOR_AREA_SQM, Math.min(MAX_FLOOR_AREA_SQM, values.floor_area_sqm))
+          : MIN_FLOOR_AREA_SQM;
       const requestBody: PredictionRequestBody = {
         mlModel: values.ml_model,
         town: values.town,
         storeyRange: values.storey_range,
         flatModel: values.flat_model,
-        floorAreaSqm: values.floor_area_sqm,
+        floorAreaSqm: floorArea,
         leaseCommenceYear: values.lease_commence_date.year,
       };
       try {

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -331,7 +331,7 @@ function PredictionClientInner() {
     const handler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
         e.preventDefault();
-        if (!loadingRef.current) handleFinish(formValues);
+        if (!loadingRef.current) handleFinish(latestFormRef.current);
       }
       if (
         e.key === "Escape" &&
@@ -344,7 +344,7 @@ function PredictionClientInner() {
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [loading, lang, formValues, handleFinish, handleReset, announce]);
+  }, [lang, handleFinish, handleReset, announce]);
 
   const figures = [
     {

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -85,6 +85,7 @@ function PredictionClientInner() {
   const resultsRef = useRef<HTMLDivElement>(null);
   const liveRef = useRef<HTMLDivElement>(null);
   const requestControllerRef = useRef<AbortController | null>(null);
+  const loadingRef = useRef(false);
   const latestFormRef = useRef(formValues);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
@@ -93,13 +94,20 @@ function PredictionClientInner() {
     latestFormRef.current = formValues;
   }, [formValues]);
 
+  // Keep loadingRef in sync to prevent stale closure in keyboard shortcut
+  useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
   const announce = useCallback((message: string, priority: "polite" | "assertive" = "polite") => {
     if (!liveRef.current) return;
     liveRef.current.setAttribute("aria-live", priority);
     liveRef.current.textContent = "";
-    requestAnimationFrame(() => {
+    // Use setTimeout instead of rAF so the announcement fires even in background tabs.
+    // The small delay (50ms) ensures screen readers detect the text change.
+    setTimeout(() => {
       if (liveRef.current) liveRef.current.textContent = message;
-    });
+    }, 50);
   }, []);
 
   useEffect(() => {
@@ -323,7 +331,7 @@ function PredictionClientInner() {
     const handler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
         e.preventDefault();
-        if (!loading) handleFinish(formValues);
+        if (!loadingRef.current) handleFinish(formValues);
       }
       if (
         e.key === "Escape" &&

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -55,7 +55,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 const panelCard =
-  "relative overflow-hidden border-border/60 shadow-sm ring-1 ring-foreground/5 transition-all duration-300 hover:shadow-md hover:shadow-primary/5";
+  "relative overflow-hidden border-border/60 shadow-none transition-all duration-300";
 
 export default function PredictionClient() {
   return (
@@ -364,7 +364,7 @@ function PredictionClientInner() {
       <main className="min-h-screen px-6 pb-12 pt-5" aria-busy="true">
         <div className="mx-auto max-w-7xl space-y-5">
           <Skeleton className="animate-shimmer h-10 w-full max-w-md rounded-xl" />
-          <div className="grid grid-cols-2 gap-5 max-[860px]:grid-cols-1">
+          <div className="grid grid-cols-2 gap-5 max-[960px]:grid-cols-1">
             <Skeleton className="animate-shimmer h-64 rounded-xl" />
             <Skeleton className="animate-shimmer h-96 rounded-xl" />
           </div>
@@ -395,9 +395,9 @@ function PredictionClientInner() {
       />
 
       <div className="mx-auto max-w-7xl">
-        <header className="animate-fade-in-deep sticky top-0 z-20 -mx-6 mb-6 flex items-center justify-between gap-4 border-b border-border/50 bg-background/85 px-6 py-4 backdrop-blur-md max-sm:relative max-sm:mx-0 max-sm:flex-col max-sm:items-start max-sm:px-0">
+        <header className="sticky top-0 z-20 -mx-6 mb-6 flex items-center justify-between gap-4 border-b border-border/50 bg-background/85 px-6 py-4 backdrop-blur-md max-sm:relative max-sm:mx-0 max-sm:flex-col max-sm:items-start max-sm:px-0">
           <div className="flex items-center gap-2.5">
-            <span className="font-heading text-base font-bold tracking-tight">{t("brand")}</span>
+            <span className="font-sans text-xs font-bold tracking-tight">{t("brand")}</span>
             <Badge variant="secondary" className="gap-1">
               <Sparkles className="size-3" aria-hidden />
               {t("badge")}
@@ -437,36 +437,28 @@ function PredictionClientInner() {
           </div>
         </header>
 
-        <div className="grid grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] items-start gap-5 max-[860px]:grid-cols-1">
+        <div className="grid grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] items-start gap-5 max-[960px]:grid-cols-1">
           <div className="flex flex-col gap-5">
             <Card
               size="sm"
-              className={cn(panelCard, "animate-fade-in-deep border-l-4 border-l-primary/70 py-6")}
+              className={cn(panelCard, "py-6")}
             >
-              <div
-                className="pointer-events-none absolute -right-20 -top-16 size-56 rounded-full bg-primary/15 blur-3xl"
-                aria-hidden
-              />
-              <div
-                className="pointer-events-none absolute -bottom-20 -left-16 size-48 rounded-full bg-chart-2/15 blur-3xl"
-                aria-hidden
-              />
-              <CardHeader className="relative px-6 pb-0">
+              <CardHeader className="px-6 pb-0">
                 <CardTitle
                   asChild
                   className={cn(
-                    "font-heading whitespace-pre-line text-[clamp(2rem,5vw,3rem)] font-bold normal-case tracking-tight",
+                    "whitespace-pre-line text-[clamp(1.8rem,4vw,2.4rem)] font-extrabold normal-case tracking-tight",
                     isZh && "font-cjk font-extrabold",
                   )}
                 >
                   <h1>{t("price_prediction")}</h1>
                 </CardTitle>
-                <CardDescription className="max-w-prose text-base leading-relaxed">
+                <CardDescription className="max-w-prose text-sm leading-relaxed">
                   {t("intro_blurb")}
                 </CardDescription>
               </CardHeader>
               <CardContent className="relative px-6 pt-4">
-                <div className="animate-stagger grid grid-cols-3 gap-2.5 max-sm:grid-cols-1">
+                <div className="grid grid-cols-3 gap-2.5 max-sm:grid-cols-1">
                   {figures.map((figure) => (
                     <StatTile
                       key={figure.label}
@@ -483,7 +475,7 @@ function PredictionClientInner() {
               </CardContent>
             </Card>
 
-            <Card size="sm" className={cn(panelCard, "animate-fade-in-deep border-l-4 border-l-primary/70 py-6")}>
+            <Card size="sm" className={cn(panelCard, "py-6")}>
               <CardHeader className="px-6 pb-2">
                 <CardTitle asChild className="text-primary normal-case">
                   <h2>{t("prediction_form")}</h2>

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -83,6 +83,8 @@ function PredictionClientInner() {
   });
   const hasRestoredRef = useRef(false);
   const resultsRef = useRef<HTMLDivElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const liveRef = useRef<HTMLDivElement>(null);
   const requestControllerRef = useRef<AbortController | null>(null);
   const latestFormRef = useRef(formValues);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -91,6 +93,15 @@ function PredictionClientInner() {
   useEffect(() => {
     latestFormRef.current = formValues;
   }, [formValues]);
+
+  const announce = useCallback((message: string, priority: "polite" | "assertive" = "polite") => {
+    if (!liveRef.current) return;
+    liveRef.current.setAttribute("aria-live", priority);
+    liveRef.current.textContent = "";
+    requestAnimationFrame(() => {
+      if (liveRef.current) liveRef.current.textContent = message;
+    });
+  }, []);
 
   useEffect(() => {
     const isDark = localStorage.getItem(STORAGE_KEYS.theme) === "dark";
@@ -149,6 +160,10 @@ function PredictionClientInner() {
   useEffect(() => {
     if (output > 0) {
       resultsRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      // Focus management: move focus to results area after prediction
+      setTimeout(() => {
+        resultsRef.current?.focus({ preventScroll: false });
+      }, 100);
     }
   }, [output]);
 
@@ -281,6 +296,12 @@ function PredictionClientInner() {
           lease_commence_date: values.lease_commence_date,
         });
         toast.success(t("prediction_success"), { id: "prediction" });
+        announce(
+          lang === "zh"
+            ? `预测完成。预估价格：$${Math.round(predictedPrice).toLocaleString()}`
+            : `Prediction complete. Estimated price: $${Math.round(predictedPrice).toLocaleString()}`,
+          "assertive",
+        );
       } catch (err: unknown) {
         if (isAbortError(err)) return;
         setOutput(0);
@@ -297,6 +318,26 @@ function PredictionClientInner() {
     },
     [t],
   );
+
+  // Keyboard shortcuts: Ctrl/Cmd+Enter to submit, Escape to reset
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+        e.preventDefault();
+        if (!loading) handleFinish(formValues);
+      }
+      if (
+        e.key === "Escape" &&
+        !document.querySelector('[role="listbox"]') &&
+        formRef.current?.contains(document.activeElement)
+      ) {
+        handleReset();
+        announce(lang === "zh" ? "表单已重置" : "Form reset");
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [loading, lang, formValues, handleFinish, handleReset, announce]);
 
   const figures = [
     {
@@ -337,6 +378,23 @@ function PredictionClientInner() {
 
   return (
     <main className="min-h-screen px-6 pb-12 pt-5 max-sm:px-3 max-sm:pb-8">
+      {/* Skip navigation — visible on focus for keyboard users */}
+      <a
+        href="#input-ml_model"
+        className="fixed -left-[9999px] top-auto z-[100] h-px w-px overflow-hidden focus:fixed focus:left-4 focus:top-4 focus:h-auto focus:w-auto focus:overflow-visible focus:rounded-lg focus:bg-primary focus:px-5 focus:py-2.5 focus:text-sm focus:font-bold focus:text-primary-foreground focus:no-underline focus:shadow-lg"
+      >
+        Skip to form
+      </a>
+
+      {/* Live region for screen reader announcements */}
+      <div
+        ref={liveRef}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="absolute size-px overflow-hidden whitespace-nowrap border-0 p-0 [clip:rect(0,0,0,0)]"
+      />
+
       <div className="mx-auto max-w-7xl">
         <header className="animate-fade-in-deep sticky top-0 z-20 -mx-6 mb-6 flex items-center justify-between gap-4 border-b border-border/50 bg-background/85 px-6 py-4 backdrop-blur-md max-sm:relative max-sm:mx-0 max-sm:flex-col max-sm:items-start max-sm:px-0">
           <div className="flex items-center gap-2.5">
@@ -420,6 +478,9 @@ function PredictionClientInner() {
                     />
                   ))}
                 </div>
+                <p className="mt-3.5 text-[0.82rem] leading-relaxed text-muted-foreground">
+                  {t("intro_caption")}
+                </p>
               </CardContent>
             </Card>
 
@@ -430,11 +491,6 @@ function PredictionClientInner() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="px-6">
-                {loading && (
-                  <div className="progress-track mb-4" role="progressbar" aria-label={t("predicting")}>
-                    <div className="progress-bar" style={{ width: "60%" }} />
-                  </div>
-                )}
                 {error && !loading && (
                   <div role="alert" className="mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
                     {error}
@@ -448,11 +504,16 @@ function PredictionClientInner() {
                   onValuesChange={handleFormChange}
                   t={t}
                 />
+                {loading && (
+                  <div className="progress-track mt-4" role="progressbar" aria-label={t("predicting")}>
+                    <div className="progress-bar" style={{ width: "60%" }} />
+                  </div>
+                )}
               </CardContent>
             </Card>
           </div>
 
-          <div ref={resultsRef}>
+          <div ref={resultsRef} tabIndex={-1} className="outline-none" aria-label={t("predicted_price")}>
             <PredictionResults
               output={output}
               summaryValues={summaryValues}

--- a/components/prediction/PredictionForm.tsx
+++ b/components/prediction/PredictionForm.tsx
@@ -8,8 +8,9 @@ import { MAX_FLOOR_AREA_SQM, MIN_FLOOR_AREA_SQM } from "../../lib/prediction";
 import { FLAT_MODELS, ML_MODELS, STOREY_RANGES, TOWNS, LEASE_COMMENCE_YEARS } from "../../lib/lists";
 import { FormSelect, type FormSelectOption } from "@/components/ui/form-select";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Field, FieldContent, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
+import { NumberField } from "@/components/ui/number-field";
 import type { FieldType } from "./types";
 
 type PredictionFormProps = {
@@ -49,7 +50,10 @@ export default function PredictionForm({
     () => labeledOptions(ML_MODELS, (m) => t(`ml_models.${m}`, m)),
     [t],
   );
-  const townOptions = useMemo(() => labeledOptions(TOWNS, (m) => t(`towns.${m}`, m)), [t]);
+  const townComboboxOptions: ComboboxOption[] = useMemo(
+    () => TOWNS.map((town) => ({ value: town, label: t(`towns.${town}`, town) })),
+    [t],
+  );
   const storeyOptions = useMemo(
     () => labeledOptions(STOREY_RANGES, (m) => t(`storey_ranges.${m}`, m)),
     [t],
@@ -83,12 +87,13 @@ export default function PredictionForm({
           <Field>
             <FieldLabel htmlFor="input-town">{t("town")}</FieldLabel>
             <FieldContent>
-              <FormSelect
+              <Combobox
                 id="input-town"
                 value={formValues.town}
-                onChange={(value) => handleChange("town", value)}
-                options={townOptions}
+                onChange={(value) => handleChange("town", value as typeof formValues.town)}
+                options={townComboboxOptions}
                 placeholder={t("select_town")}
+                ariaLabel={t("town")}
               />
             </FieldContent>
           </Field>
@@ -119,31 +124,17 @@ export default function PredictionForm({
           <Field>
             <FieldLabel htmlFor="input-floor_area">{t("floor_area")}</FieldLabel>
             <FieldContent>
-              <div className="group flex rounded-lg border border-border/60 bg-card shadow-sm transition-all duration-200 hover:border-primary/30 hover:shadow-md hover:shadow-primary/5 focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/15 focus-within:shadow-md focus-within:shadow-primary/10">
-                <Input
-                  id="input-floor_area"
-                  type="number"
-                  inputMode="numeric"
-                  enterKeyHint="done"
-                  aria-describedby="floor-area-unit"
-                  className="h-10 rounded-r-none rounded-l-lg border-0 bg-transparent px-3 shadow-none focus-visible:ring-0 focus-visible:border-transparent outline-none focus:outline-none"
-                  min={MIN_FLOOR_AREA_SQM}
-                  max={MAX_FLOOR_AREA_SQM}
-                  value={formValues.floor_area_sqm || ""}
-                  placeholder={t("enter_floor_area")}
-                  onChange={(e) =>
-                    handleChange("floor_area_sqm", e.target.value ? Number(e.target.value) : 0)
-                  }
-                  required
-                />
-                <span
-                  id="floor-area-unit"
-                  className="inline-flex h-10 items-center rounded-r-lg border-l border-border/60 bg-muted px-3 text-xs font-semibold text-muted-foreground transition-colors duration-200 group-hover:border-l-primary/30 group-focus-within:border-l-primary/50"
-                >
-                  <span className="sr-only">{t("floor_area_unit")}</span>
-                  <span aria-hidden>m²</span>
-                </span>
-              </div>
+              <NumberField
+                id="input-floor_area"
+                value={formValues.floor_area_sqm || ""}
+                onChange={(value) => handleChange("floor_area_sqm", value || 0)}
+                min={MIN_FLOOR_AREA_SQM}
+                max={MAX_FLOOR_AREA_SQM}
+                step={5}
+                placeholder={t("enter_floor_area")}
+                unit="m²"
+                ariaLabel={t("floor_area")}
+              />
             </FieldContent>
           </Field>
         </div>

--- a/components/prediction/PredictionForm.tsx
+++ b/components/prediction/PredictionForm.tsx
@@ -83,7 +83,7 @@ export default function PredictionForm({
           </FieldContent>
         </Field>
 
-        <div className="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+        <div className="grid grid-cols-2 gap-4 max-[520px]:grid-cols-1">
           <Field>
             <FieldLabel htmlFor="input-town">{t("town")}</FieldLabel>
             <FieldContent>
@@ -154,11 +154,11 @@ export default function PredictionForm({
           </FieldContent>
         </Field>
 
-        <div className="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
+        <div className="grid grid-cols-2 gap-3 max-[520px]:grid-cols-1">
           <Button
             type="submit"
             size="lg"
-            className="w-full normal-case tracking-normal shadow-md shadow-primary/20 transition-all duration-200 hover:shadow-lg hover:shadow-primary/25 hover:brightness-110"
+            className="w-full normal-case tracking-normal transition-all duration-200 hover:brightness-110"
             disabled={loading}
           >
             {loading ? (
@@ -174,7 +174,7 @@ export default function PredictionForm({
             type="button"
             variant="outline"
             size="lg"
-            className="w-full normal-case tracking-normal transition-all duration-200 hover:bg-muted/80"
+            className="w-full normal-case tracking-normal transition-all duration-200"
             onClick={onReset}
           >
             {t("reset_form")}

--- a/components/prediction/PredictionForm.tsx
+++ b/components/prediction/PredictionForm.tsx
@@ -126,14 +126,15 @@ export default function PredictionForm({
             <FieldContent>
               <NumberField
                 id="input-floor_area"
-                value={formValues.floor_area_sqm || ""}
-                onChange={(value) => handleChange("floor_area_sqm", value || 0)}
+                value={typeof formValues.floor_area_sqm === "number" ? formValues.floor_area_sqm : ""}
+                onChange={(value) => handleChange("floor_area_sqm", value === "" ? 0 : value)}
                 min={MIN_FLOOR_AREA_SQM}
                 max={MAX_FLOOR_AREA_SQM}
                 step={5}
                 placeholder={t("enter_floor_area")}
                 unit="m²"
                 ariaLabel={t("floor_area")}
+                required
               />
             </FieldContent>
           </Field>

--- a/components/prediction/PredictionResults.tsx
+++ b/components/prediction/PredictionResults.tsx
@@ -5,7 +5,6 @@ import { useMemo, memo } from "react";
 import { Home, Layers, MapPin, TrendingDown, TrendingUp } from "lucide-react";
 import type { TFunction } from "../../lib/i18n";
 import type { SummaryValues, TrendPoint } from "./types";
-import { ResultsSkeleton } from "./results-skeleton";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -48,7 +47,6 @@ export default memo(function PredictionResults({
   loading = false,
 }: PredictionResultsProps) {
   const hasOutput = output > 0;
-  const showSkeleton = loading && !hasOutput;
 
   const chartStats = useMemo(() => {
     const latestValue = trendData[trendData.length - 1]?.value ?? 0;
@@ -125,29 +123,22 @@ export default memo(function PredictionResults({
             <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
               {t("prediction")}
             </p>
-            {showSkeleton ? (
-              <Skeleton className="animate-shimmer mt-2 h-9 w-36 rounded-lg" />
-            ) : (
-              <p
-                key={output}
-                className={cn(
-                  "mt-1 font-sans text-3xl font-extrabold tabular-nums tracking-tight transition-all duration-500",
-                  !hasOutput && "text-base font-semibold text-muted-foreground",
-                  hasOutput && "text-primary animate-settle",
-                )}
-              >
-                {hasOutput ? fmt(output) : t("awaiting")}
-              </p>
-            )}
+            <p
+              key={output}
+              className={cn(
+                "mt-1 font-sans text-3xl font-extrabold tabular-nums tracking-tight transition-all duration-500",
+                loading && !hasOutput && "animate-pulse text-base font-semibold text-muted-foreground",
+                !loading && !hasOutput && "text-base font-semibold text-muted-foreground",
+                hasOutput && "text-primary animate-settle",
+              )}
+            >
+              {hasOutput ? fmt(output) : loading ? t("predicting") : t("awaiting")}
+            </p>
           </div>
         </CardHeader>
 
-        <CardContent className="relative flex flex-col gap-5 px-6">
-          {showSkeleton ? (
-            <ResultsSkeleton />
-          ) : (
-            <>
-              <div className="grid grid-cols-3 gap-2.5 max-sm:grid-cols-1">
+        <CardContent className="flex flex-col gap-5 px-6">
+          <div className="grid grid-cols-3 gap-2.5 max-sm:grid-cols-1">
                 {summaryItems.map((item, i) => {
                   const Icon = item.icon;
                   return (
@@ -216,16 +207,14 @@ export default memo(function PredictionResults({
                       />
                     ))}
                   </div>
-                  <h3 className="animate-fade-in font-sans text-base font-semibold text-foreground">
+                  <h3 className="font-sans text-base font-semibold text-foreground">
                     {t("placeholder_title")}
                   </h3>
-                  <p className="animate-fade-in mx-auto max-w-[32ch] text-sm leading-relaxed text-muted-foreground" style={{ animationDelay: "0.08s", animationFillMode: "both" }}>
+                  <p className="mx-auto max-w-[32ch] text-sm leading-relaxed text-muted-foreground">
                     {t("placeholder_body")}
                   </p>
                 </div>
               )}
-            </>
-          )}
         </CardContent>
       </Card>
     </section>

--- a/components/prediction/PredictionResults.tsx
+++ b/components/prediction/PredictionResults.tsx
@@ -28,7 +28,7 @@ const PriceTrendChart = dynamic(() => import("./PriceTrendChart"), {
 });
 
 const panelCard =
-  "relative overflow-hidden border-border/60 shadow-sm ring-1 ring-foreground/5 transition-all duration-300 hover:shadow-md hover:shadow-primary/5";
+  "relative overflow-hidden border-border/60 shadow-none transition-all duration-300";
 
 type PredictionResultsProps = {
   output: number;
@@ -99,11 +99,7 @@ export default memo(function PredictionResults({
 
   return (
     <section aria-labelledby="prediction-results-heading" aria-busy={loading}>
-      <Card size="sm" className={cn(panelCard, "animate-fade-in-deep border-l-4 border-l-primary/70 py-6")}>
-        <div
-          className="pointer-events-none absolute -right-24 -top-24 size-64 rounded-full bg-primary/10 blur-3xl"
-          aria-hidden
-        />
+      <Card size="sm" className={cn(panelCard, "py-6")}>
         <CardHeader className="relative flex flex-row items-start justify-between gap-4 px-6 pb-2 max-sm:flex-col">
           <div>
             <Badge variant="secondary" className="mb-2">
@@ -111,36 +107,31 @@ export default memo(function PredictionResults({
             </Badge>
             <CardTitle
               asChild
-              className="font-heading text-2xl normal-case tracking-tight"
+              className="font-sans text-2xl font-extrabold normal-case tracking-tight"
             >
               <h2 id="prediction-results-heading">{t("predicted_price")}</h2>
             </CardTitle>
           </div>
           <div
             className={cn(
-              "relative min-w-[200px] overflow-hidden rounded-xl border px-5 py-4 max-sm:w-full transition-all duration-500",
+              "min-w-[200px] overflow-hidden rounded-[var(--radius-sm,3px)] border px-4 py-3 max-sm:w-full transition-all duration-300",
               hasOutput
-                ? "border-primary/25 bg-gradient-to-br from-primary/12 via-accent/60 to-card animate-glow"
-                : "border-border/60 bg-gradient-to-br from-secondary/40 to-card",
-              "shadow-[inset_0_1px_0_0_color-mix(in_oklab,var(--primary-foreground)_12%,transparent)]",
+                ? "border-primary/25 bg-primary/5"
+                : "border-border bg-secondary",
             )}
             aria-live="polite"
             aria-atomic="true"
           >
-            <div
-              className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,color-mix(in_oklab,var(--primary)_18%,transparent),transparent_55%)]"
-              aria-hidden
-            />
-            <p className="relative text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
               {t("prediction")}
             </p>
             {showSkeleton ? (
-              <Skeleton className="animate-shimmer relative mt-2 h-9 w-36 rounded-lg" />
+              <Skeleton className="animate-shimmer mt-2 h-9 w-36 rounded-lg" />
             ) : (
               <p
                 key={output}
                 className={cn(
-                  "relative mt-1 font-heading text-3xl font-extrabold tabular-nums tracking-tight transition-all duration-500",
+                  "mt-1 font-sans text-3xl font-extrabold tabular-nums tracking-tight transition-all duration-500",
                   !hasOutput && "text-base font-semibold text-muted-foreground",
                   hasOutput && "text-primary animate-settle",
                 )}
@@ -162,11 +153,11 @@ export default memo(function PredictionResults({
                   return (
                     <div
                       key={item.label}
-                      className="animate-fade-in flex items-center gap-3 rounded-xl border border-border/60 bg-secondary/40 p-3 backdrop-blur-sm transition-all duration-300 hover:border-primary/20 hover:bg-secondary/60 hover:shadow-sm"
+                      className="animate-fade-in flex items-center gap-3 rounded-[var(--radius-sm,3px)] border border-border bg-secondary p-3 transition-all duration-200 hover:border-primary/25"
                       style={{ animationDelay: `${i * 0.08}s`, animationFillMode: "both" }}
                     >
                       <div
-                        className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/15"
+                        className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md,6px)] bg-primary/10"
                         aria-hidden
                       >
                         <Icon className="size-4 text-primary" />
@@ -189,7 +180,7 @@ export default memo(function PredictionResults({
                     <CardDescription className="mb-1 uppercase tracking-wider">
                       {t("predicted_trends")}
                     </CardDescription>
-                    <h3 className="mb-3 font-heading text-sm font-semibold normal-case">
+                    <h3 className="mb-3 font-sans text-sm font-semibold normal-case">
                       {t("chart_story_title")}
                     </h3>
                     <div className="mb-4 grid grid-cols-3 gap-2.5 max-sm:grid-cols-1">
@@ -216,7 +207,7 @@ export default memo(function PredictionResults({
                 </>
               ) : (
                 <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-border/70 bg-gradient-to-b from-muted/30 to-transparent px-4 py-12 text-center">
-                  <div className="empty-float flex items-end gap-1.5 opacity-40" aria-hidden>
+                  <div className="flex items-end gap-1.5 opacity-40" aria-hidden>
                     {[0.35, 0.55, 0.85, 0.45, 0.7, 0.3].map((h, i) => (
                       <div
                         key={i}
@@ -225,7 +216,7 @@ export default memo(function PredictionResults({
                       />
                     ))}
                   </div>
-                  <h3 className="animate-fade-in font-heading text-base font-semibold text-foreground">
+                  <h3 className="animate-fade-in font-sans text-base font-semibold text-foreground">
                     {t("placeholder_title")}
                   </h3>
                   <p className="animate-fade-in mx-auto max-w-[32ch] text-sm leading-relaxed text-muted-foreground" style={{ animationDelay: "0.08s", animationFillMode: "both" }}>
@@ -255,7 +246,7 @@ function StatChip({
   const TrendIcon = trend === "down" ? TrendingDown : trend === "up" ? TrendingUp : null;
 
   return (
-    <div className="rounded-xl border border-border/60 bg-secondary/40 px-3 py-2.5 backdrop-blur-sm transition-all duration-300 hover:border-primary/20 hover:shadow-sm">
+    <div className="rounded-[var(--radius-sm,3px)] border border-border bg-secondary px-3 py-2.5 transition-all duration-200 hover:border-primary/25">
       <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">{label}</p>
       <p
         className={cn(

--- a/components/prediction/PriceTrendChart.tsx
+++ b/components/prediction/PriceTrendChart.tsx
@@ -72,7 +72,7 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
     const lastIdx = values.length - 1;
 
     return { pts, linePath, areaPath, yTicks, peakIdx, lastIdx };
-  }, [data, padL, padT, cW, cH]);
+  }, [data, cW, cH]);
 
   const { fmtFull, fmtK } = useMemo(() => {
     const formatter = new Intl.NumberFormat(locale === "zh" ? "zh-SG" : "en-SG", {
@@ -131,7 +131,6 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
             <stop offset="60%" stopColor="var(--color-chart)" stopOpacity="0.06" />
             <stop offset="100%" stopColor="var(--color-chart)" stopOpacity="0" />
           </linearGradient>
-          {/* v5: horizontal gradient for line stroke */}
           <linearGradient id={lineGradId} x1="0" y1="0" x2="1" y2="0">
             <stop offset="0%" stopColor="var(--color-chart)" />
             <stop offset="100%" stopColor="var(--chart-2, var(--color-chart))" />
@@ -139,7 +138,6 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
         </defs>
         {yTicks.map((t, i) => (
           <g key={i}>
-            {/* v5: dashed grid lines for non-baseline ticks */}
             <line x1={padL} x2={W - padR} y1={t.y} y2={t.y}
               stroke="var(--color-border)" strokeWidth="1"
               strokeDasharray={i === 0 ? "none" : "3 4"} />
@@ -150,11 +148,8 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
           <text key={i} x={p.x} y={padT + cH + 22} textAnchor="middle" className="chart-axis-label">{p.label.slice(5)}</text>
         ))}
         <path d={areaPath} fill={`url(#${gradId})`} />
-        {/* v5: gradient line stroke */}
         <path d={linePath} fill="none" stroke={`url(#${lineGradId})`} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-        {/* v5: peak dot uses chart-2 for visual hierarchy */}
         <circle cx={pts[peakIdx].x} cy={pts[peakIdx].y} r="4" fill="var(--chart-2, var(--color-primary))" stroke="var(--color-surface)" strokeWidth="2" />
-        {/* v5: glow ring behind latest dot */}
         <circle cx={pts[lastIdx].x} cy={pts[lastIdx].y} r="7" fill="var(--color-chart)" fillOpacity="0.15" stroke="none" />
         {/* Latest dot */}
         <circle cx={pts[lastIdx].x} cy={pts[lastIdx].y} r="5" fill="var(--color-primary)" stroke="var(--color-surface)" strokeWidth="2.5" />

--- a/components/prediction/PriceTrendChart.tsx
+++ b/components/prediction/PriceTrendChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState, useMemo } from "react";
+import React, { useRef, useState, useMemo, useId } from "react";
 import type { TrendPoint } from "./types";
 
 type PriceTrendChartProps = {
@@ -10,6 +10,9 @@ type PriceTrendChartProps = {
 
 export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const uid = useId();
+  const gradId = `chartGrad-${uid}`;
+  const lineGradId = `chartLineGrad-${uid}`;
   const [tooltip, setTooltip] = useState<{
     idx: number;
     x: number;
@@ -22,9 +25,6 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
   const padL = 56, padR = 18, padT = 20, padB = 36;
   const cW = W - padL - padR, cH = H - padT - padB;
 
-  // ⚡ Bolt Optimization: Memoize expensive calculations
-  // Impact: Prevents recalculation of chart data and SVG paths on every mouse move
-  // Measurement: Significant reduction in CPU time during hover events
   const chartData = useMemo(() => {
     if (!data || data.length === 0) return null;
 
@@ -74,9 +74,7 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
     return { pts, linePath, areaPath, yTicks, peakIdx, lastIdx };
   }, [data, padL, padT, cW, cH]);
 
-  // ⚡ Bolt Optimization: Memoize Intl.NumberFormat
-  // Impact: NumberFormat instantiation is slow. Memoizing it prevents re-creation on every render.
-  const { formatter, fmtFull, fmtK } = useMemo(() => {
+  const { fmtFull, fmtK } = useMemo(() => {
     const formatter = new Intl.NumberFormat(locale === "zh" ? "zh-SG" : "en-SG", {
       style: "currency",
       currency: "SGD",
@@ -88,7 +86,7 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
       if (v >= 1e3) return `${Math.round(v / 1e3)}k`;
       return fmtFull(v);
     };
-    return { formatter, fmtFull, fmtK };
+    return { fmtFull, fmtK };
   }, [locale]);
 
   if (!chartData) return null;
@@ -104,8 +102,6 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
       if (dist < closestDist) { closestDist = dist; closest = i; }
     });
 
-    // ⚡ Bolt Optimization: Bail out of state updates if tooltip index hasn't changed
-    // Impact: Completely bypasses React reconciliation when mouse moves within the same data point's bounds
     setTooltip((prev) => {
       if (prev && prev.idx === closest) return prev;
       const p = chartData.pts[closest];
@@ -130,13 +126,13 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
         aria-label="Price trend chart"
       >
         <defs>
-          <linearGradient id="chartGrad" x1="0" y1="0" x2="0" y2="1">
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
             <stop offset="0%" stopColor="var(--color-chart)" stopOpacity="0.28" />
             <stop offset="60%" stopColor="var(--color-chart)" stopOpacity="0.06" />
             <stop offset="100%" stopColor="var(--color-chart)" stopOpacity="0" />
           </linearGradient>
           {/* v5: horizontal gradient for line stroke */}
-          <linearGradient id="chartLineGrad" x1="0" y1="0" x2="1" y2="0">
+          <linearGradient id={lineGradId} x1="0" y1="0" x2="1" y2="0">
             <stop offset="0%" stopColor="var(--color-chart)" />
             <stop offset="100%" stopColor="var(--chart-2, var(--color-chart))" />
           </linearGradient>
@@ -153,9 +149,9 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
         {pts.filter((_, i) => i % 3 === 0 || i === lastIdx).map((p, i) => (
           <text key={i} x={p.x} y={padT + cH + 22} textAnchor="middle" className="chart-axis-label">{p.label.slice(5)}</text>
         ))}
-        <path d={areaPath} fill="url(#chartGrad)" />
+        <path d={areaPath} fill={`url(#${gradId})`} />
         {/* v5: gradient line stroke */}
-        <path d={linePath} fill="none" stroke="url(#chartLineGrad)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d={linePath} fill="none" stroke={`url(#${lineGradId})`} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
         {/* v5: peak dot uses chart-2 for visual hierarchy */}
         <circle cx={pts[peakIdx].x} cy={pts[peakIdx].y} r="4" fill="var(--chart-2, var(--color-primary))" stroke="var(--color-surface)" strokeWidth="2" />
         {/* v5: glow ring behind latest dot */}

--- a/components/prediction/PriceTrendChart.tsx
+++ b/components/prediction/PriceTrendChart.tsx
@@ -135,10 +135,18 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
             <stop offset="60%" stopColor="var(--color-chart)" stopOpacity="0.06" />
             <stop offset="100%" stopColor="var(--color-chart)" stopOpacity="0" />
           </linearGradient>
+          {/* v5: horizontal gradient for line stroke */}
+          <linearGradient id="chartLineGrad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="var(--color-chart)" />
+            <stop offset="100%" stopColor="var(--chart-2, var(--color-chart))" />
+          </linearGradient>
         </defs>
         {yTicks.map((t, i) => (
           <g key={i}>
-            <line x1={padL} x2={W - padR} y1={t.y} y2={t.y} stroke="var(--color-border)" strokeWidth="1" />
+            {/* v5: dashed grid lines for non-baseline ticks */}
+            <line x1={padL} x2={W - padR} y1={t.y} y2={t.y}
+              stroke="var(--color-border)" strokeWidth="1"
+              strokeDasharray={i === 0 ? "none" : "3 4"} />
             <text x={padL - 10} y={t.y + 4} textAnchor="end" className="chart-tick-text">{fmtK(t.val)}</text>
           </g>
         ))}
@@ -146,9 +154,12 @@ export default function PriceTrendChart({ data, locale }: PriceTrendChartProps) 
           <text key={i} x={p.x} y={padT + cH + 22} textAnchor="middle" className="chart-axis-label">{p.label.slice(5)}</text>
         ))}
         <path d={areaPath} fill="url(#chartGrad)" />
-        <path d={linePath} fill="none" stroke="var(--color-chart)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
-        {/* Peak dot */}
-        <circle cx={pts[peakIdx].x} cy={pts[peakIdx].y} r="4" fill="var(--color-primary)" stroke="var(--color-surface)" strokeWidth="2" />
+        {/* v5: gradient line stroke */}
+        <path d={linePath} fill="none" stroke="url(#chartLineGrad)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        {/* v5: peak dot uses chart-2 for visual hierarchy */}
+        <circle cx={pts[peakIdx].x} cy={pts[peakIdx].y} r="4" fill="var(--chart-2, var(--color-primary))" stroke="var(--color-surface)" strokeWidth="2" />
+        {/* v5: glow ring behind latest dot */}
+        <circle cx={pts[lastIdx].x} cy={pts[lastIdx].y} r="7" fill="var(--color-chart)" fillOpacity="0.15" stroke="none" />
         {/* Latest dot */}
         <circle cx={pts[lastIdx].x} cy={pts[lastIdx].y} r="5" fill="var(--color-primary)" stroke="var(--color-surface)" strokeWidth="2.5" />
         {/* Hover line + dot */}

--- a/components/prediction/stat-tile.tsx
+++ b/components/prediction/stat-tile.tsx
@@ -22,23 +22,23 @@ export function StatTile({ icon: Icon, label, value, hint, className }: StatTile
     <div
       tabIndex={hint ? 0 : undefined}
       className={cn(
-        "group/tile flex items-center gap-3 rounded-xl border border-border/60 bg-card/90 p-4 shadow-sm transition-all duration-300",
-        "hover:-translate-y-0.5 hover:border-primary/25 hover:shadow-md hover:shadow-primary/5",
+        "group/tile flex items-center gap-3 rounded-[var(--radius-xl,8px)] border border-border bg-card p-3 transition-all duration-200",
+        "hover:border-primary/25",
         hint && "cursor-help focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         className,
       )}
     >
       <div
-        className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 ring-1 ring-primary/15 transition-all duration-300 group-hover/tile:bg-primary/15 group-hover/tile:ring-primary/25"
+        className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius-md,6px)] bg-primary/10 transition-all duration-200 group-hover/tile:bg-primary/15"
         aria-hidden
       >
-        <Icon className="size-5 text-primary" />
+        <Icon className="size-4 text-primary" />
       </div>
       <div className="flex min-w-0 flex-col gap-0.5">
         <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
           {label}
         </span>
-        <strong className="font-heading text-xl font-extrabold tabular-nums tracking-tight text-primary">
+        <strong className="font-sans text-lg font-extrabold tabular-nums tracking-tight text-primary">
           {value}
         </strong>
       </div>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -13,7 +13,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-8 overflow-hidden bg-card py-8 text-sm text-card-foreground shadow-sm ring-1 ring-foreground/5 dark:ring-0 dark:shadow-[0_0_0_1px_color-mix(in_oklab,var(--primary)_7%,transparent),0_4px_24px_rgba(4,12,24,0.55)] has-[>img:first-child]:pt-0 data-[size=sm]:gap-5 data-[size=sm]:py-5 *:[img:first-child]:rounded-none *:[img:last-child]:rounded-none",
+        "group/card flex flex-col gap-8 overflow-hidden bg-card py-8 text-sm text-card-foreground border border-border dark:border-0 dark:shadow-[0_0_0_1px_color-mix(in_oklab,var(--primary)_7%,transparent)] has-[>img:first-child]:pt-0 data-[size=sm]:gap-5 data-[size=sm]:py-5 *:[img:first-child]:rounded-none *:[img:last-child]:rounded-none",
         className
       )}
       {...props}
@@ -44,7 +44,7 @@ function CardTitle({
     <Comp
       data-slot="card-title"
       className={cn(
-        "font-heading text-lg font-semibold tracking-wider uppercase",
+        "font-sans text-lg font-semibold tracking-wider uppercase",
         className,
       )}
       {...props}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -217,6 +217,7 @@ export function Combobox({
                   id={`${id}-opt-${i}`}
                   role="option"
                   aria-selected={isSelected}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(opt.value)}
                   onMouseEnter={() => setActiveIndex(i)}
                   className={cn(

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -43,6 +43,7 @@ export function Combobox({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const suppressFocusOpenRef = useRef(false);
 
   const selectedLabel = useMemo(() => {
     const opt = options.find((o) => o.value === value);
@@ -80,6 +81,7 @@ export function Combobox({
       setQuery("");
       setIsOpen(false);
       setActiveIndex(-1);
+      suppressFocusOpenRef.current = true;
       inputRef.current?.focus();
     },
     [onChange],
@@ -155,8 +157,12 @@ export function Combobox({
           onKeyDown={handleKeyDown}
           onFocus={() => {
             setFocused(true);
-            setIsOpen(true);
-            setQuery("");
+            if (suppressFocusOpenRef.current) {
+              suppressFocusOpenRef.current = false;
+            } else {
+              setIsOpen(true);
+              setQuery("");
+            }
           }}
           onBlur={(e) => {
             setFocused(false);

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -101,9 +101,11 @@ export function Combobox({
         if (isOpen) setActiveIndex((i) => Math.max(i - 1, 0));
         break;
       case "Enter":
-        e.preventDefault();
-        if (isOpen && activeIndex >= 0 && filtered[activeIndex]) {
-          handleSelect(filtered[activeIndex].value);
+        if (isOpen) {
+          e.preventDefault();
+          if (activeIndex >= 0 && filtered[activeIndex]) {
+            handleSelect(filtered[activeIndex].value);
+          }
         }
         break;
       case "Escape":
@@ -156,7 +158,13 @@ export function Combobox({
             setIsOpen(true);
             setQuery("");
           }}
-          onBlur={() => setFocused(false)}
+          onBlur={(e) => {
+            setFocused(false);
+            if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+              setIsOpen(false);
+              setQuery("");
+            }
+          }}
           autoComplete="off"
           spellCheck={false}
           className={cn(

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import {
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+  type KeyboardEvent,
+} from "react";
+import { Check, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ComboboxOption = {
+  value: string;
+  label: string;
+};
+
+type ComboboxProps = {
+  id: string;
+  options: ComboboxOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  ariaLabel: string;
+  className?: string;
+};
+
+export function Combobox({
+  id,
+  options,
+  value,
+  onChange,
+  placeholder = "Search…",
+  ariaLabel,
+  className,
+}: ComboboxProps) {
+  const listboxId = `${id}-listbox`;
+  const [query, setQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedLabel = useMemo(() => {
+    const opt = options.find((o) => o.value === value);
+    return opt ? opt.label : "";
+  }, [options, value]);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return options;
+    const q = query.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, query]);
+
+  // Click outside → close
+  useEffect(() => {
+    const handler = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("pointerdown", handler);
+    return () => document.removeEventListener("pointerdown", handler);
+  }, []);
+
+  // Scroll active into view
+  useEffect(() => {
+    if (!isOpen || activeIndex < 0 || !listRef.current) return;
+    const items = listRef.current.querySelectorAll('[role="option"]');
+    items[activeIndex]?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, isOpen]);
+
+  const handleSelect = useCallback(
+    (optValue: string) => {
+      onChange(optValue);
+      setQuery("");
+      setIsOpen(false);
+      setActiveIndex(-1);
+      inputRef.current?.focus();
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          setActiveIndex(0);
+        } else {
+          setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+        }
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        if (isOpen) setActiveIndex((i) => Math.max(i - 1, 0));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (isOpen && activeIndex >= 0 && filtered[activeIndex]) {
+          handleSelect(filtered[activeIndex].value);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setIsOpen(false);
+        setQuery("");
+        break;
+      case "Home":
+        if (isOpen) {
+          e.preventDefault();
+          setActiveIndex(0);
+        }
+        break;
+      case "End":
+        if (isOpen) {
+          e.preventDefault();
+          setActiveIndex(filtered.length - 1);
+        }
+        break;
+    }
+  };
+
+  const activeOptionId =
+    activeIndex >= 0 ? `${id}-opt-${activeIndex}` : undefined;
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      <div className="relative flex">
+        <input
+          ref={inputRef}
+          id={id}
+          type="text"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={activeOptionId}
+          aria-autocomplete="list"
+          aria-haspopup="listbox"
+          aria-label={ariaLabel}
+          value={isOpen ? query : selectedLabel}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+            setActiveIndex(-1);
+          }}
+          onKeyDown={handleKeyDown}
+          onFocus={() => {
+            setFocused(true);
+            setIsOpen(true);
+            setQuery("");
+          }}
+          onBlur={() => setFocused(false)}
+          autoComplete="off"
+          spellCheck={false}
+          className={cn(
+            "h-[var(--height-field,42px)] w-full rounded-[var(--radius-xl,0.875rem)] border bg-card pl-3.5 pr-9 text-[0.95rem] font-semibold text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground",
+            focused
+              ? "border-primary/50 shadow-[var(--shadow-focus,0_0_0_3px_color-mix(in_oklab,var(--ring,var(--primary))_25%,transparent)),0_4px_12px_color-mix(in_oklab,var(--primary)_5%,transparent)]"
+              : "border-border/60",
+          )}
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label="Toggle options"
+          onClick={() => {
+            setIsOpen((o) => !o);
+            if (!isOpen) inputRef.current?.focus();
+          }}
+          className="absolute right-0 top-0 bottom-0 flex w-9 items-center justify-center border-none bg-transparent text-muted-foreground transition-transform duration-200"
+          style={{ transform: isOpen ? "rotate(180deg)" : "none" }}
+        >
+          <ChevronDown className="size-3" aria-hidden />
+        </button>
+      </div>
+
+      {isOpen && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
+          className="absolute z-50 left-0 right-0 top-[calc(100%+6px)] max-h-60 overflow-y-auto rounded-[var(--radius-xl,0.875rem)] border border-border/60 bg-card p-1 shadow-lg"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-3.5 py-3 text-center text-[0.85rem] italic text-muted-foreground">
+              No matches
+            </li>
+          ) : (
+            filtered.map((opt, i) => {
+              const isActive = i === activeIndex;
+              const isSelected = opt.value === value;
+              return (
+                <li
+                  key={opt.value}
+                  id={`${id}-opt-${i}`}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => handleSelect(opt.value)}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  className={cn(
+                    "flex cursor-pointer items-center justify-between gap-2 rounded-[calc(var(--radius-xl,0.875rem)-4px)] px-3 py-2.5 text-[0.9rem] transition-colors duration-100",
+                    isActive && "bg-primary/10",
+                    isSelected && "font-bold text-primary",
+                    !isActive && !isSelected && "font-semibold text-foreground",
+                  )}
+                >
+                  <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+                    {opt.label}
+                  </span>
+                  {isSelected && (
+                    <Check className="size-3.5 shrink-0 text-primary" aria-hidden />
+                  )}
+                </li>
+              );
+            })
+          )}
+          {query && filtered.length > 0 && (
+            <li className="mx-1 mt-0.5 border-t border-border/40 px-3.5 pt-2 text-center text-[0.72rem] opacity-70">
+              {filtered.length} of {options.length} options
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -168,10 +168,10 @@ export function Combobox({
           autoComplete="off"
           spellCheck={false}
           className={cn(
-            "h-[var(--height-field,42px)] w-full rounded-[var(--radius-xl,0.875rem)] border bg-card pl-3.5 pr-9 text-[0.95rem] font-semibold text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground",
+            "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border bg-card pl-3.5 pr-9 text-[0.875rem] font-medium text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground",
             focused
-              ? "border-primary/50 shadow-[var(--shadow-focus,0_0_0_3px_color-mix(in_oklab,var(--ring,var(--primary))_25%,transparent)),0_4px_12px_color-mix(in_oklab,var(--primary)_5%,transparent)]"
-              : "border-border/60",
+              ? "border-primary/50 shadow-[var(--shadow-focus)]"
+              : "border-border",
           )}
         />
         <button
@@ -195,10 +195,10 @@ export function Combobox({
           id={listboxId}
           role="listbox"
           aria-label={ariaLabel}
-          className="absolute z-50 left-0 right-0 top-[calc(100%+6px)] max-h-60 overflow-y-auto rounded-[var(--radius-xl,0.875rem)] border border-border/60 bg-card p-1 shadow-lg"
+          className="absolute z-50 left-0 right-0 top-[calc(100%+6px)] max-h-60 overflow-y-auto rounded-[var(--radius-sm,3px)] border border-border bg-card p-1 shadow-lg"
         >
           {filtered.length === 0 ? (
-            <li className="px-3.5 py-3 text-center text-[0.85rem] italic text-muted-foreground">
+            <li className="px-3.5 py-3 text-center text-[0.8125rem] italic text-muted-foreground">
               No matches
             </li>
           ) : (
@@ -214,7 +214,7 @@ export function Combobox({
                   onClick={() => handleSelect(opt.value)}
                   onMouseEnter={() => setActiveIndex(i)}
                   className={cn(
-                    "flex cursor-pointer items-center justify-between gap-2 rounded-[calc(var(--radius-xl,0.875rem)-4px)] px-3 py-2.5 text-[0.9rem] transition-colors duration-100",
+                    "flex cursor-pointer items-center justify-between gap-2 rounded-[var(--radius-sm,3px)] px-2.5 py-2 text-[0.8125rem] transition-colors duration-100",
                     isActive && "bg-primary/10",
                     isSelected && "font-bold text-primary",
                     !isActive && !isSelected && "font-semibold text-foreground",

--- a/components/ui/form-select.tsx
+++ b/components/ui/form-select.tsx
@@ -14,7 +14,7 @@ export type FormSelectOption<T extends string = string> = {
 };
 
 const triggerClassName =
-  "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border border-border bg-card px-3 transition-all duration-200 hover:border-primary/30 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/15 data-[placeholder]:text-muted-foreground";
+  "h-[var(--height-field,32px)] data-[size=default]:h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border border-border bg-card px-3 transition-all duration-200 hover:border-primary/30 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/15 data-[placeholder]:text-muted-foreground";
 
 type FormSelectProps<T extends string = string> = {
   id?: string;

--- a/components/ui/form-select.tsx
+++ b/components/ui/form-select.tsx
@@ -14,7 +14,7 @@ export type FormSelectOption<T extends string = string> = {
 };
 
 const triggerClassName =
-  "h-10 w-full rounded-lg border border-border/60 bg-card px-3 shadow-sm transition-all duration-200 hover:border-primary/30 hover:shadow-md hover:shadow-primary/5 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/15 data-[placeholder]:text-muted-foreground";
+  "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border border-border bg-card px-3 transition-all duration-200 hover:border-primary/30 focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-primary/15 data-[placeholder]:text-muted-foreground";
 
 type FormSelectProps<T extends string = string> = {
   id?: string;

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -67,6 +67,10 @@ export function NumberField({
 
   // Long-press to repeat with recursive setTimeout for dynamic acceleration
   const startHold = useCallback((fn: () => void) => {
+    if (holdRef.current) {
+      clearTimeout(holdRef.current);
+      holdRef.current = null;
+    }
     fn();
     let count = 0;
     const execute = () => {
@@ -104,11 +108,12 @@ export function NumberField({
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
-    if (raw === "") {
+    const sanitized = raw.replace(/[^0-9]/g, "");
+    if (sanitized === "") {
       onChange("");
       return;
     }
-    const n = Number(raw);
+    const n = Number(sanitized);
     if (!isNaN(n)) onChange(n);
   };
 
@@ -167,6 +172,7 @@ export function NumberField({
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={isNaN(numValue) ? undefined : numValue}
+        required={required}
         aria-required={required}
         aria-label={ariaLabel}
         value={value === "" || value === undefined ? "" : value}

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -116,10 +116,10 @@ export function NumberField({
       role="group"
       aria-label={ariaLabel}
       className={cn(
-        "grid overflow-hidden rounded-[var(--radius-xl,0.875rem)] border transition-all duration-200",
+        "grid overflow-hidden rounded-[var(--radius-sm,3px)] border transition-all duration-200",
         focused
-          ? "border-primary/50 shadow-[var(--shadow-focus,0_0_0_3px_color-mix(in_oklab,var(--ring,var(--primary))_25%,transparent)),0_4px_12px_color-mix(in_oklab,var(--primary)_5%,transparent)]"
-          : "border-border/60",
+          ? "border-primary/50 shadow-[var(--shadow-focus)]"
+          : "border-border",
         unit ? "grid-cols-[40px_1fr_auto_40px]" : "grid-cols-[40px_1fr_40px]",
         className,
       )}
@@ -162,7 +162,7 @@ export function NumberField({
         onBlur={handleBlur}
         autoComplete="off"
         className={cn(
-          "h-[var(--height-field,42px)] w-full border-x border-border/40 bg-card px-3 text-center text-[0.95rem] font-semibold tabular-nums text-foreground outline-none",
+          "h-[var(--height-field,32px)] w-full border-x border-border/40 bg-card px-3 text-center text-[0.875rem] font-medium tabular-nums text-foreground outline-none",
           "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
         )}
       />

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -31,7 +31,7 @@ export function NumberField({
 }: NumberFieldProps) {
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const holdRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const holdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const numValue = typeof value === "number" ? value : NaN;
   const clamp = useCallback(
@@ -51,19 +51,23 @@ export function NumberField({
     onChange(clamp(current - step));
   }, [numValue, min, step, clamp, onChange]);
 
-  // Long-press to repeat
+  // Long-press to repeat with recursive setTimeout for dynamic acceleration
   const startHold = useCallback((fn: () => void) => {
     fn();
     let count = 0;
-    holdRef.current = setInterval(() => {
-      count++;
-      fn();
-    }, count < 5 ? 200 : 80);
+    const execute = () => {
+      holdRef.current = setTimeout(() => {
+        count++;
+        fn();
+        execute();
+      }, count < 5 ? 200 : 80);
+    };
+    execute();
   }, []);
 
   const stopHold = useCallback(() => {
     if (holdRef.current) {
-      clearInterval(holdRef.current);
+      clearTimeout(holdRef.current);
       holdRef.current = null;
     }
   }, []);
@@ -91,7 +95,14 @@ export function NumberField({
       return;
     }
     const n = parseInt(raw, 10);
-    if (!isNaN(n)) onChange(clamp(n));
+    if (!isNaN(n)) onChange(n);
+  };
+
+  const handleBlur = () => {
+    setFocused(false);
+    if (typeof value === "number") {
+      onChange(clamp(value));
+    }
   };
 
   const stepperBtn =
@@ -145,7 +156,7 @@ export function NumberField({
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
+        onBlur={handleBlur}
         autoComplete="off"
         className={cn(
           "h-[var(--height-field,42px)] w-full border-x border-border/40 bg-card px-3 text-center text-[0.95rem] font-semibold tabular-nums text-foreground outline-none",

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useRef, useCallback, type KeyboardEvent } from "react";
+import { Minus, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type NumberFieldProps = {
+  id: string;
+  value: number | "";
+  onChange: (value: number | "") => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  placeholder?: string;
+  unit?: string;
+  ariaLabel: string;
+  className?: string;
+};
+
+export function NumberField({
+  id,
+  value,
+  onChange,
+  min = 0,
+  max = 999,
+  step = 1,
+  placeholder,
+  unit,
+  ariaLabel,
+  className,
+}: NumberFieldProps) {
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const holdRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const numValue = typeof value === "number" ? value : NaN;
+  const clamp = useCallback(
+    (v: number) => Math.max(min, Math.min(max, Math.round(v))),
+    [min, max],
+  );
+  const atMin = !isNaN(numValue) && numValue <= min;
+  const atMax = !isNaN(numValue) && numValue >= max;
+
+  const increment = useCallback(() => {
+    const current = isNaN(numValue) ? min : numValue;
+    onChange(clamp(current + step));
+  }, [numValue, min, step, clamp, onChange]);
+
+  const decrement = useCallback(() => {
+    const current = isNaN(numValue) ? min : numValue;
+    onChange(clamp(current - step));
+  }, [numValue, min, step, clamp, onChange]);
+
+  // Long-press to repeat
+  const startHold = useCallback((fn: () => void) => {
+    fn();
+    let count = 0;
+    holdRef.current = setInterval(() => {
+      count++;
+      fn();
+    }, count < 5 ? 200 : 80);
+  }, []);
+
+  const stopHold = useCallback(() => {
+    if (holdRef.current) {
+      clearInterval(holdRef.current);
+      holdRef.current = null;
+    }
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      increment();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      decrement();
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      onChange(min);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      onChange(max);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    if (raw === "") {
+      onChange("");
+      return;
+    }
+    const n = parseInt(raw, 10);
+    if (!isNaN(n)) onChange(clamp(n));
+  };
+
+  const stepperBtn =
+    "flex items-center justify-center border-none bg-secondary/60 text-secondary-foreground transition-all duration-150 p-0 cursor-pointer font-[inherit] hover:bg-primary/10 hover:text-primary";
+
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={cn(
+        "grid overflow-hidden rounded-[var(--radius-xl,0.875rem)] border transition-all duration-200",
+        focused
+          ? "border-primary/50 shadow-[var(--shadow-focus,0_0_0_3px_color-mix(in_oklab,var(--ring,var(--primary))_25%,transparent)),0_4px_12px_color-mix(in_oklab,var(--primary)_5%,transparent)]"
+          : "border-border/60",
+        unit ? "grid-cols-[40px_1fr_auto_40px]" : "grid-cols-[40px_1fr_40px]",
+        className,
+      )}
+    >
+      {/* Decrement */}
+      <button
+        type="button"
+        tabIndex={-1}
+        disabled={atMin}
+        aria-label="Decrease value"
+        onPointerDown={(e) => {
+          if (!atMin) {
+            e.preventDefault();
+            startHold(decrement);
+          }
+        }}
+        onPointerUp={stopHold}
+        onPointerLeave={stopHold}
+        className={cn(stepperBtn, atMin && "cursor-not-allowed opacity-35")}
+      >
+        <Minus className="size-3.5" aria-hidden />
+      </button>
+
+      {/* Input */}
+      <input
+        ref={inputRef}
+        id={id}
+        type="text"
+        inputMode="numeric"
+        role="spinbutton"
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={isNaN(numValue) ? undefined : numValue}
+        aria-label={ariaLabel}
+        value={value === "" || value === undefined ? "" : value}
+        placeholder={placeholder}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        autoComplete="off"
+        className={cn(
+          "h-[var(--height-field,42px)] w-full border-x border-border/40 bg-card px-3 text-center text-[0.95rem] font-semibold tabular-nums text-foreground outline-none",
+          "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+        )}
+      />
+
+      {/* Unit label */}
+      {unit && (
+        <span
+          className="flex items-center border-r border-border/40 bg-secondary/60 px-3.5 text-xs font-bold whitespace-nowrap text-muted-foreground"
+          aria-hidden="true"
+        >
+          {unit}
+        </span>
+      )}
+
+      {/* Increment */}
+      <button
+        type="button"
+        tabIndex={-1}
+        disabled={atMax}
+        aria-label="Increase value"
+        onPointerDown={(e) => {
+          if (!atMax) {
+            e.preventDefault();
+            startHold(increment);
+          }
+        }}
+        onPointerUp={stopHold}
+        onPointerLeave={stopHold}
+        className={cn(stepperBtn, atMax && "cursor-not-allowed opacity-35")}
+      >
+        <Plus className="size-3.5" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, type KeyboardEvent } from "react";
+import { useState, useRef, useCallback, useEffect, type KeyboardEvent } from "react";
 import { Minus, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -32,6 +32,9 @@ export function NumberField({
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const holdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const valueRef = useRef(value);
+
+  useEffect(() => { valueRef.current = value; }, [value]);
 
   const numValue = typeof value === "number" ? value : NaN;
   const clamp = useCallback(
@@ -42,14 +45,14 @@ export function NumberField({
   const atMax = !isNaN(numValue) && numValue >= max;
 
   const increment = useCallback(() => {
-    const current = isNaN(numValue) ? min : numValue;
+    const current = typeof valueRef.current === "number" ? valueRef.current : min;
     onChange(clamp(current + step));
-  }, [numValue, min, step, clamp, onChange]);
+  }, [min, step, clamp, onChange]);
 
   const decrement = useCallback(() => {
-    const current = isNaN(numValue) ? min : numValue;
+    const current = typeof valueRef.current === "number" ? valueRef.current : min;
     onChange(clamp(current - step));
-  }, [numValue, min, step, clamp, onChange]);
+  }, [min, step, clamp, onChange]);
 
   // Long-press to repeat with recursive setTimeout for dynamic acceleration
   const startHold = useCallback((fn: () => void) => {

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -14,6 +14,7 @@ type NumberFieldProps = {
   placeholder?: string;
   unit?: string;
   ariaLabel: string;
+  required?: boolean;
   className?: string;
 };
 
@@ -27,14 +28,24 @@ export function NumberField({
   placeholder,
   unit,
   ariaLabel,
+  required = false,
   className,
 }: NumberFieldProps) {
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const holdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const valueRef = useRef(value);
-
   useEffect(() => { valueRef.current = value; }, [value]);
+
+  // Cleanup hold timer on unmount
+  useEffect(() => {
+    return () => {
+      if (holdRef.current) {
+        clearTimeout(holdRef.current);
+        holdRef.current = null;
+      }
+    };
+  }, []);
 
   const numValue = typeof value === "number" ? value : NaN;
   const clamp = useCallback(
@@ -97,14 +108,17 @@ export function NumberField({
       onChange("");
       return;
     }
-    const n = parseInt(raw, 10);
+    const n = Number(raw);
     if (!isNaN(n)) onChange(n);
   };
 
   const handleBlur = () => {
     setFocused(false);
-    if (typeof value === "number") {
-      onChange(clamp(value));
+    // Read the latest value from the ref to avoid the falsy-zero pitfall
+    // where the prop value is "" but the ref still holds the last number.
+    const latest = valueRef.current;
+    if (typeof latest === "number") {
+      onChange(clamp(latest));
     }
   };
 
@@ -153,6 +167,7 @@ export function NumberField({
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={isNaN(numValue) ? undefined : numValue}
+        aria-required={required}
         aria-label={ariaLabel}
         value={value === "" || value === undefined ? "" : value}
         placeholder={placeholder}
@@ -175,6 +190,10 @@ export function NumberField({
         >
           {unit}
         </span>
+      )}
+      {/* Accessible unit label for screen readers */}
+      {unit && (
+        <span className="sr-only">{unit === "m²" ? "square meters" : unit}</span>
       )}
 
       {/* Increment */}


### PR DESCRIPTION
## Summary

Implements the v5 design handoff, focusing on accessibility and interaction improvements on top of the existing indigo v4 design.

## Changes

### New Components
- **Combobox** — Searchable dropdown with typeahead filtering, WAI-ARIA combobox/listbox roles, keyboard navigation (↑↓ Enter Esc Home End), click-outside-to-close
- **NumberField** — Stepper input with −/+ buttons, long-press repeat (200ms → 80ms acceleration), ArrowUp/Down keyboard support, Home/End for min/max, WAI-ARIA spinbutton

### Accessibility
- Live region for screen reader announcements on prediction completion
- Focus management — focus moves to results area after prediction
- Skip-navigation link for keyboard users (visible on focus)
- Keyboard shortcuts: Ctrl/Cmd+Enter to submit, Escape to reset

### Chart Refinements
- Gradient line stroke (horizontal gradient from chart-1 → chart-2)
- Dashed grid lines for non-baseline ticks
- Glow ring behind latest dot
- Peak dot uses chart-2 color for visual hierarchy

### UI
- Town field now uses Combobox instead of plain select (26 towns with typeahead)
- Floor Area now uses NumberField with stepper buttons instead of plain number input
- Intro caption text below stat tiles
- Progress bar repositioned below form (matching design)
- Focus-visible CSS and listbox scrollbar styles