### PR TITLE
Add aria-valuemin/aria-valuemax to progress bar

### DIFF
--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -510,7 +510,7 @@ function PredictionClientInner() {
                   t={t}
                 />
                 {loading && (
-                  <div className="progress-track mt-4" role="progressbar" aria-label={t("predicting")}>
+                  <div className="progress-track mt-4" role="progressbar" aria-label={t("predicting")} aria-valuemin={0} aria-valuemax={100}>
                     <div className="progress-bar" style={{ width: "60%" }} />
                   </div>
                 )}


### PR DESCRIPTION
Aligns with [prediction-tool-svelte#38](https://github.com/shenghaoc/prediction-tool-svelte/pull/38).

The `role="progressbar"` div already had `aria-label`; the two boundary attributes were missing, leaving screen readers without explicit min/max context for the indeterminate indicator.

https://claude.ai/code/session_01VSrDwtrmE3HM4ZDbsMbVXY