### PR TITLE
🎨 Palette: Unify composite input focus & hover states

### DIFF
--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -171,8 +171,7 @@ export function Combobox({
           autoComplete="off"
           spellCheck={false}
           className={cn(
-            "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border bg-card pl-3.5 pr-9 text-[0.875rem] font-medium text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground",
-            "border-border hover:border-primary/30 focus-visible:border-primary/50 focus-visible:shadow-[var(--shadow-focus)]",
+            "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border border-border bg-card pl-3.5 pr-9 text-[0.875rem] font-medium text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground hover:border-primary/30 focus-visible:border-primary/50 focus-visible:shadow-[var(--shadow-focus)]",
           )}
         />
         <button

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -39,7 +39,6 @@ export function Combobox({
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
-  const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -156,7 +155,6 @@ export function Combobox({
           }}
           onKeyDown={handleKeyDown}
           onFocus={() => {
-            setFocused(true);
             if (suppressFocusOpenRef.current) {
               suppressFocusOpenRef.current = false;
             } else {
@@ -165,7 +163,6 @@ export function Combobox({
             }
           }}
           onBlur={(e) => {
-            setFocused(false);
             if (!containerRef.current?.contains(e.relatedTarget as Node)) {
               setIsOpen(false);
               setQuery("");
@@ -175,9 +172,7 @@ export function Combobox({
           spellCheck={false}
           className={cn(
             "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border bg-card pl-3.5 pr-9 text-[0.875rem] font-medium text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground",
-            focused
-              ? "border-primary/50 shadow-[var(--shadow-focus)]"
-              : "border-border",
+            "border-border hover:border-primary/30 focus-visible:border-primary/50 focus-visible:shadow-[var(--shadow-focus)]",
           )}
         />
         <button

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -170,9 +170,7 @@ export function Combobox({
           }}
           autoComplete="off"
           spellCheck={false}
-          className={cn(
-            "h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border border-border bg-card pl-3.5 pr-9 text-[0.875rem] font-medium text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground hover:border-primary/30 focus-visible:border-primary/50 focus-visible:shadow-[var(--shadow-focus)]",
-          )}
+          className="h-[var(--height-field,32px)] w-full rounded-[var(--radius-sm,3px)] border border-border bg-card pl-3.5 pr-9 text-[0.875rem] font-medium text-foreground outline-none transition-all duration-200 placeholder:text-muted-foreground hover:border-primary/30 focus-visible:border-primary/50 focus-visible:shadow-[var(--shadow-focus)]"
         />
         <button
           type="button"

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect, type KeyboardEvent } from "react";
+import { useRef, useCallback, useEffect, type KeyboardEvent } from "react";
 import { Minus, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -31,7 +31,6 @@ export function NumberField({
   required = false,
   className,
 }: NumberFieldProps) {
-  const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const holdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const valueRef = useRef(value);
@@ -118,7 +117,6 @@ export function NumberField({
   };
 
   const handleBlur = () => {
-    setFocused(false);
     // Read the latest value from the ref to avoid the falsy-zero pitfall
     // where the prop value is "" but the ref still holds the last number.
     const latest = valueRef.current;
@@ -136,9 +134,7 @@ export function NumberField({
       aria-label={ariaLabel}
       className={cn(
         "grid overflow-hidden rounded-[var(--radius-sm,3px)] border transition-all duration-200",
-        focused
-          ? "border-primary/50 shadow-[var(--shadow-focus)]"
-          : "border-border",
+        "border-border hover:border-primary/30 focus-within:border-primary/50 focus-within:shadow-[var(--shadow-focus)]",
         unit ? "grid-cols-[40px_1fr_auto_40px]" : "grid-cols-[40px_1fr_40px]",
         className,
       )}
@@ -179,7 +175,6 @@ export function NumberField({
         placeholder={placeholder}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
-        onFocus={() => setFocused(true)}
         onBlur={handleBlur}
         autoComplete="off"
         className={cn(

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -133,8 +133,7 @@ export function NumberField({
       role="group"
       aria-label={ariaLabel}
       className={cn(
-        "grid overflow-hidden rounded-[var(--radius-sm,3px)] border transition-all duration-200",
-        "border-border hover:border-primary/30 focus-within:border-primary/50 focus-within:shadow-[var(--shadow-focus)]",
+        "grid overflow-hidden rounded-[var(--radius-sm,3px)] border border-border transition-all duration-200 hover:border-primary/30 focus-within:border-primary/50 focus-within:shadow-[var(--shadow-focus)]",
         unit ? "grid-cols-[40px_1fr_auto_40px]" : "grid-cols-[40px_1fr_40px]",
         className,
       )}


### PR DESCRIPTION
💡 What: Replaced manual React state (`focused`) with native CSS `focus-within`, `focus-visible`, and `hover` states for `NumberField` and `Combobox` components.

🎯 Why: Managing focus states manually via React `useState` and `onFocus`/`onBlur` handlers inside complex composite inputs is prone to race conditions, requires unnecessary re-renders, and can fail to capture focus events triggered outside the main input (e.g. clicking the +/- stepper buttons). Delegating this to native CSS pseudo-classes ensures perfect reliability, improves performance by reducing renders, and creates a more cohesive, interactive experience.

📸 Before/After: Before, `NumberField` had no hover border state and could potentially lose the focus ring state if a sub-element received focus. After, hover interactions are immediately responsive and the focus ring perfectly wraps the entire composite field naturally via `focus-within`. `Combobox` now also utilizes native CSS state pseudo-classes. 

♿ Accessibility: Ensures that keyboard users tab-navigating onto the stepper buttons in `NumberField` still receive a clear, whole-component focus indication.

---
*PR created automatically by Jules for task [17204709358729677554](https://jules.google.com/task/17204709358729677554) started by @shenghaoc*