### PR TITLE
⚡ Bolt: [performance improvement] Add client-side caching for prediction API requests

### DIFF
--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -280,11 +280,6 @@ function PredictionClientInner() {
 
   const handleFinish = useCallback(
     async (values: FieldType) => {
-      requestControllerRef.current?.abort();
-      const controller = new AbortController();
-      requestControllerRef.current = controller;
-      setLoading(true);
-      setError(null);
       const floorArea =
         typeof values.floor_area_sqm === "number"
           ? Math.max(MIN_FLOOR_AREA_SQM, Math.min(MAX_FLOOR_AREA_SQM, values.floor_area_sqm))
@@ -298,37 +293,7 @@ function PredictionClientInner() {
         leaseCommenceYear: values.lease_commence_date.year,
       };
 
-      // ⚡ Bolt: Cache API responses to prevent redundant network requests
-      // when users toggle inputs back and forth or submit identical queries.
-      const cacheKey = getPredictionCacheKey(requestBody);
-      let serverData: ApiResponse;
-
-      try {
-        if (predictionCacheRef.current.has(cacheKey)) {
-          serverData = predictionCacheRef.current.get(cacheKey)!;
-        } else {
-          setOutput(0);
-          setTrendData(defaultTrendData);
-          const response = await fetch("/api/prices", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: cacheKey,
-            signal: controller.signal,
-          });
-          if (!response.ok) {
-            throw new Error(await getResponseErrorMessage(response, t("error_fetch")));
-          }
-          serverData = await response.json();
-
-          if (predictionCacheRef.current.size >= MAX_PREDICTION_CACHE_SIZE) {
-            const oldestKey = predictionCacheRef.current.keys().next().value;
-            if (oldestKey !== undefined) {
-              predictionCacheRef.current.delete(oldestKey);
-            }
-          }
-          predictionCacheRef.current.set(cacheKey, serverData);
-        }
-
+      const applyServerData = (serverData: ApiResponse) => {
         const normalizedData = normalizeTrendData(serverData);
         if (!trendDataHasValidPrices(normalizedData)) {
           throw new Error(t("error_invalid_prediction"));
@@ -348,6 +313,56 @@ function PredictionClientInner() {
             : `Prediction complete. Estimated price: $${Math.round(predictedPrice).toLocaleString()}`,
           "assertive",
         );
+      };
+
+      // ⚡ Bolt: Cache API responses to prevent redundant network requests
+      // when users toggle inputs back and forth or submit identical queries.
+      const cacheKey = getPredictionCacheKey(requestBody);
+      const cached = predictionCacheRef.current.get(cacheKey);
+      if (cached) {
+        predictionCacheRef.current.delete(cacheKey);
+        predictionCacheRef.current.set(cacheKey, cached);
+        try {
+          setError(null);
+          applyServerData(cached);
+        } catch (err: unknown) {
+          setOutput(0);
+          setTrendData(defaultTrendData);
+          const msg = getErrorMessage(err, t("error_fetch"));
+          setError(msg);
+          toast.error(msg);
+        }
+        return;
+      }
+
+      requestControllerRef.current?.abort();
+      const controller = new AbortController();
+      requestControllerRef.current = controller;
+      setLoading(true);
+      setError(null);
+      setOutput(0);
+      setTrendData(defaultTrendData);
+
+      try {
+        const response = await fetch("/api/prices", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: cacheKey,
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(await getResponseErrorMessage(response, t("error_fetch")));
+        }
+        const serverData: ApiResponse = await response.json();
+
+        if (predictionCacheRef.current.size >= MAX_PREDICTION_CACHE_SIZE) {
+          const oldestKey = predictionCacheRef.current.keys().next().value;
+          if (oldestKey !== undefined) {
+            predictionCacheRef.current.delete(oldestKey);
+          }
+        }
+        predictionCacheRef.current.set(cacheKey, serverData);
+        applyServerData(serverData);
       } catch (err: unknown) {
         if (isAbortError(err)) return;
         setOutput(0);

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -90,6 +90,7 @@ function PredictionClientInner() {
   const loadingRef = useRef(false);
   const latestFormRef = useRef(formValues);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const predictionCacheRef = useRef<Record<string, ApiResponse>>({});
 
   // Keep latestFormRef in sync without triggering re-renders
   useEffect(() => {
@@ -271,8 +272,6 @@ function PredictionClientInner() {
       requestControllerRef.current = controller;
       setLoading(true);
       setError(null);
-      setOutput(0);
-      setTrendData(defaultTrendData);
       const floorArea =
         typeof values.floor_area_sqm === "number"
           ? Math.max(MIN_FLOOR_AREA_SQM, Math.min(MAX_FLOOR_AREA_SQM, values.floor_area_sqm))
@@ -285,17 +284,31 @@ function PredictionClientInner() {
         floorAreaSqm: floorArea,
         leaseCommenceYear: values.lease_commence_date.year,
       };
+
+      // ⚡ Bolt: Cache API responses to prevent redundant network requests
+      // when users toggle inputs back and forth or submit identical queries.
+      const cacheKey = JSON.stringify(requestBody);
+      let serverData: ApiResponse;
+
       try {
-        const response = await fetch("/api/prices", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(requestBody),
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(await getResponseErrorMessage(response, t("error_fetch")));
+        if (predictionCacheRef.current[cacheKey]) {
+          serverData = predictionCacheRef.current[cacheKey];
+        } else {
+          setOutput(0);
+          setTrendData(defaultTrendData);
+          const response = await fetch("/api/prices", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: cacheKey,
+            signal: controller.signal,
+          });
+          if (!response.ok) {
+            throw new Error(await getResponseErrorMessage(response, t("error_fetch")));
+          }
+          serverData = await response.json();
+          predictionCacheRef.current[cacheKey] = serverData;
         }
-        const serverData: ApiResponse = await response.json();
+
         const normalizedData = normalizeTrendData(serverData);
         if (!trendDataHasValidPrices(normalizedData)) {
           throw new Error(t("error_invalid_prediction"));

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -44,6 +44,19 @@ import {
   normalizeTrendData,
   trendDataHasValidPrices,
 } from "./utils";
+
+const MAX_PREDICTION_CACHE_SIZE = 50;
+
+function getPredictionCacheKey(body: PredictionRequestBody): string {
+  return JSON.stringify(
+    Object.keys(body)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = body[key as keyof PredictionRequestBody];
+        return acc;
+      }, {}),
+  );
+}
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -90,7 +103,7 @@ function PredictionClientInner() {
   const loadingRef = useRef(false);
   const latestFormRef = useRef(formValues);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const predictionCacheRef = useRef<Record<string, ApiResponse>>({});
+  const predictionCacheRef = useRef<Map<string, ApiResponse>>(new Map());
 
   // Keep latestFormRef in sync without triggering re-renders
   useEffect(() => {
@@ -287,12 +300,12 @@ function PredictionClientInner() {
 
       // ⚡ Bolt: Cache API responses to prevent redundant network requests
       // when users toggle inputs back and forth or submit identical queries.
-      const cacheKey = JSON.stringify(requestBody);
+      const cacheKey = getPredictionCacheKey(requestBody);
       let serverData: ApiResponse;
 
       try {
-        if (predictionCacheRef.current[cacheKey]) {
-          serverData = predictionCacheRef.current[cacheKey];
+        if (predictionCacheRef.current.has(cacheKey)) {
+          serverData = predictionCacheRef.current.get(cacheKey)!;
         } else {
           setOutput(0);
           setTrendData(defaultTrendData);
@@ -306,7 +319,14 @@ function PredictionClientInner() {
             throw new Error(await getResponseErrorMessage(response, t("error_fetch")));
           }
           serverData = await response.json();
-          predictionCacheRef.current[cacheKey] = serverData;
+
+          if (predictionCacheRef.current.size >= MAX_PREDICTION_CACHE_SIZE) {
+            const oldestKey = predictionCacheRef.current.keys().next().value;
+            if (oldestKey !== undefined) {
+              predictionCacheRef.current.delete(oldestKey);
+            }
+          }
+          predictionCacheRef.current.set(cacheKey, serverData);
         }
 
         const normalizedData = normalizeTrendData(serverData);

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -44,6 +44,17 @@ import {
   normalizeTrendData,
   trendDataHasValidPrices,
 } from "./utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 const MAX_PREDICTION_CACHE_SIZE = 50;
 
@@ -57,17 +68,6 @@ function getPredictionCacheKey(body: PredictionRequestBody): string {
       }, {}),
   );
 }
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { cn } from "@/lib/utils";
 
 const panelCard =
   "relative overflow-hidden border-border/60 shadow-none transition-all duration-300";


### PR DESCRIPTION
💡 What: Implemented a client-side cache using `useRef` to store API responses keyed by the stringified request body in `PredictionClient`.
🎯 Why: To prevent redundant network roundtrips and avoid UI flashing when users toggle form inputs back and forth or submit identical queries.
📊 Impact: Eliminates API calls and UI loading states (flashing text/charts) entirely for previously requested predictions. The UI resolves instantly.
🔬 Measurement: Verify by submitting a prediction, changing a form value, and changing it back. The second identical submission should not trigger a network request.

---
*PR created automatically by Jules for task [313738038499342108](https://jules.google.com/task/313738038499342108) started by @shenghaoc*