### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing input length limits on API endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -8,7 +8,7 @@
 **Learning:** Next.js applications require explicit configuration in `next.config.js` to serve these headers globally to all routes.
 **Prevention:** Include baseline CSP and Permissions-Policy in boilerplate Next.js setups to secure against XSS and excessive browser permissions.
 
-## 2025-02-12 - Prevent DoS via Input Size Limits on API Endpoints
+## 2026-05-29 - Prevent DoS via Input Size Limits on API Endpoints
 **Vulnerability:** The API `/api/prices` parsed JSON directly from incoming requests (`await request.json()`) without restricting the request body size. This exposed the application to Denial-of-Service (DoS) and memory exhaustion attacks from maliciously large payloads.
 **Learning:** Next.js Route Handlers (`app/api/`) deployed to edge networks (e.g. Cloudflare) inherit stream limits but don't strictly enforce pre-parse string limits. Without a length check before parsing, large strings could crash the isolated process or exceed edge limits abruptly.
 **Prevention:** Always read the raw text (`await request.text()`) and enforce a safe maximum length constraint before invoking `JSON.parse()`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was missing defense-in-depth security headers like `Content-Security-Policy` and `Permissions-Policy`.
 **Learning:** Next.js applications require explicit configuration in `next.config.js` to serve these headers globally to all routes.
 **Prevention:** Include baseline CSP and Permissions-Policy in boilerplate Next.js setups to secure against XSS and excessive browser permissions.
+
+## 2025-02-12 - Prevent DoS via Input Size Limits on API Endpoints
+**Vulnerability:** The API `/api/prices` parsed JSON directly from incoming requests (`await request.json()`) without restricting the request body size. This exposed the application to Denial-of-Service (DoS) and memory exhaustion attacks from maliciously large payloads.
+**Learning:** Next.js Route Handlers (`app/api/`) deployed to edge networks (e.g. Cloudflare) inherit stream limits but don't strictly enforce pre-parse string limits. Without a length check before parsing, large strings could crash the isolated process or exceed edge limits abruptly.
+**Prevention:** Always read the raw text (`await request.text()`) and enforce a safe maximum length constraint before invoking `JSON.parse()`.

--- a/app/api/prices/route.test.ts
+++ b/app/api/prices/route.test.ts
@@ -111,6 +111,10 @@ describe('POST /api/prices error responses', () => {
 });
 
 describe('POST /api/prices payload length', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	test('returns 413 when request payload is too large', async () => {
 		const largeBody = { ...validRequestBody, extra: 'a'.repeat(3000) };
 		const response = await POST(createPostRequest(largeBody));
@@ -118,5 +122,24 @@ describe('POST /api/prices payload length', () => {
 
 		expect(response.status).toBe(413);
 		expect(body.error).toBe('Request payload too large.');
+	});
+
+	test('does not reject payload of exactly 2048 characters', async () => {
+		const request = new Request('http://localhost/api/prices', {
+			method: 'POST',
+			body: 'a'.repeat(2048)
+		});
+		const response = await POST(request);
+		expect(response.status).not.toBe(413);
+	});
+
+	test('rejects payload of exactly 2049 characters', async () => {
+		const request = new Request('http://localhost/api/prices', {
+			method: 'POST',
+			body: 'a'.repeat(2049)
+		});
+		const response = await POST(request);
+
+		expect(response.status).toBe(413);
 	});
 });

--- a/app/api/prices/route.test.ts
+++ b/app/api/prices/route.test.ts
@@ -109,3 +109,14 @@ describe('POST /api/prices error responses', () => {
 		expect(JSON.stringify(body)).not.toContain(sensitiveDbError);
 	});
 });
+
+describe('POST /api/prices payload length', () => {
+	test('returns 413 when request payload is too large', async () => {
+		const largeBody = { ...validRequestBody, extra: 'a'.repeat(3000) };
+		const response = await POST(createPostRequest(largeBody));
+		const body = (await response.json()) as { error?: string };
+
+		expect(response.status).toBe(413);
+		expect(body.error).toBe('Request payload too large.');
+	});
+});

--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -36,7 +36,12 @@ export async function POST(request: Request) {
 	let requestBody: unknown;
 
 	try {
-		requestBody = await request.json();
+		// Security enhancement: Limit input length to prevent memory exhaustion / DoS
+		const rawBody = await request.text();
+		if (rawBody.length > 2048) {
+			return NextResponse.json({ error: 'Request payload too large.' }, { status: 413 });
+		}
+		requestBody = JSON.parse(rawBody);
 	} catch {
 		return NextResponse.json({ error: 'Invalid JSON request body.' }, { status: 400 });
 	}

--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -38,8 +38,8 @@ export async function POST(request: Request) {
 	try {
 		const contentLength = request.headers.get('content-length');
 		if (contentLength !== null) {
-			const length = parseInt(contentLength, 10);
-			if (Number.isNaN(length) || length > 2048) {
+			const length = Number(contentLength);
+			if (Number.isNaN(length) || length < 0 || length > 2048) {
 				return NextResponse.json({ error: 'Request payload too large.' }, { status: 413 });
 			}
 		}

--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -36,7 +36,6 @@ export async function POST(request: Request) {
 	let requestBody: unknown;
 
 	try {
-		// Security enhancement: Limit input length to prevent memory exhaustion / DoS
 		const rawBody = await request.text();
 		if (rawBody.length > 2048) {
 			return NextResponse.json({ error: 'Request payload too large.' }, { status: 413 });

--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -36,6 +36,13 @@ export async function POST(request: Request) {
 	let requestBody: unknown;
 
 	try {
+		const contentLength = request.headers.get('content-length');
+		if (contentLength !== null) {
+			const length = parseInt(contentLength, 10);
+			if (Number.isNaN(length) || length > 2048) {
+				return NextResponse.json({ error: 'Request payload too large.' }, { status: 413 });
+			}
+		}
 		const rawBody = await request.text();
 		if (rawBody.length > 2048) {
 			return NextResponse.json({ error: 'Request payload too large.' }, { status: 413 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limit on `POST /api/prices` could allow malicious users to send extremely large JSON payloads, potentially causing memory exhaustion and event loop blocking during parsing.
🎯 Impact: Denial-of-Service (DoS) and excessive memory utilization for the server process/edge worker.
🔧 Fix: Add a check to limit the length of the raw request payload (2048 characters) before proceeding with `JSON.parse`. Returns a `413 Payload Too Large` if exceeded.
✅ Verification: Ensure tests pass via `pnpm test`, which now includes a test case asserting the 413 response is returned for large payloads.

---
*PR created automatically by Jules for task [12665050080894155446](https://jules.google.com/task/12665050080894155446) started by @shenghaoc*