### PR TITLE
🛡️ Sentinel: [HIGH] Fix simple request CSRF in /api/prices

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The API `/api/prices` parsed JSON directly from incoming requests (`await request.json()`) without restricting the request body size. This exposed the application to Denial-of-Service (DoS) and memory exhaustion attacks from maliciously large payloads.
 **Learning:** Next.js Route Handlers (`app/api/`) deployed to edge networks (e.g. Cloudflare) inherit stream limits but don't strictly enforce pre-parse string limits. Without a length check before parsing, large strings could crash the isolated process or exceed edge limits abruptly.
 **Prevention:** Always read the raw text (`await request.text()`) and enforce a safe maximum length constraint before invoking `JSON.parse()`.
+
+## 2026-06-03 - Prevent Simple Request CSRF via Content-Type Validation
+**Vulnerability:** The API `/api/prices` parsed request bodies as JSON regardless of the `Content-Type` header. This allowed "Simple Requests" (e.g., `text/plain`, `application/x-www-form-urlencoded` submitted via standard HTML forms) to bypass CORS preflight checks and submit data to the API, exposing the application to simple CSRF and MIME confusion attacks.
+**Learning:** Next.js Route Handlers do not automatically validate `Content-Type` headers before reading request payloads. Without explicit validation, cross-origin HTML forms can POST data to the endpoint.
+**Prevention:** Always explicitly validate that the `Content-Type` header matches the expected media type (e.g., `application/json`) before parsing request bodies, returning a `415 Unsupported Media Type` if the validation fails.

--- a/app/api/prices/route.test.ts
+++ b/app/api/prices/route.test.ts
@@ -127,6 +127,7 @@ describe('POST /api/prices payload length', () => {
 	test('does not reject payload of exactly 2048 characters', async () => {
 		const request = new Request('http://localhost/api/prices', {
 			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
 			body: 'a'.repeat(2048)
 		});
 		const response = await POST(request);
@@ -136,10 +137,22 @@ describe('POST /api/prices payload length', () => {
 	test('rejects payload of exactly 2049 characters', async () => {
 		const request = new Request('http://localhost/api/prices', {
 			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
 			body: 'a'.repeat(2049)
 		});
 		const response = await POST(request);
 
 		expect(response.status).toBe(413);
+	});
+
+	test('rejects requests without application/json content-type', async () => {
+		const request = new Request('http://localhost/api/prices', {
+			method: 'POST',
+			headers: { 'Content-Type': 'text/plain' },
+			body: JSON.stringify(validRequestBody)
+		});
+		const response = await POST(request);
+
+		expect(response.status).toBe(415);
 	});
 });

--- a/app/api/prices/route.test.ts
+++ b/app/api/prices/route.test.ts
@@ -155,4 +155,26 @@ describe('POST /api/prices payload length', () => {
 
 		expect(response.status).toBe(415);
 	});
+
+	test('rejects content-type that only embeds application/json in a parameter', async () => {
+		const request = new Request('http://localhost/api/prices', {
+			method: 'POST',
+			headers: { 'Content-Type': 'text/plain; charset=utf-8; boundary=application/json' },
+			body: JSON.stringify(validRequestBody)
+		});
+		const response = await POST(request);
+
+		expect(response.status).toBe(415);
+	});
+
+	test('accepts application/json with parameters', async () => {
+		const request = new Request('http://localhost/api/prices', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json; charset=utf-8' },
+			body: JSON.stringify(validRequestBody)
+		});
+		const response = await POST(request);
+
+		expect(response.status).not.toBe(415);
+	});
 });

--- a/app/api/prices/route.test.ts
+++ b/app/api/prices/route.test.ts
@@ -71,6 +71,31 @@ function mockDbThatThrows(message: string) {
 	} as ReturnType<typeof getCloudflareContext>);
 }
 
+function mockDbWithValidResults() {
+	const mockAll = vi.fn().mockResolvedValue({
+		results: [
+			{
+				intercept_map: 1,
+				month_map: 1,
+				storey_range_map: 1,
+				floor_area_sqm_map: 1,
+				lease_commence_date_map: 1,
+				month_name: '2022-02',
+				month_multiplier: 1,
+				town_map: 1,
+				flat_model_map: 1,
+				storey_range_multiplier: 1
+			}
+		]
+	});
+	const mockBind = vi.fn().mockReturnValue({ all: mockAll });
+	const mockPrepare = vi.fn().mockReturnValue({ bind: mockBind });
+
+	vi.mocked(getCloudflareContext).mockReturnValue({
+		env: { DB: { prepare: mockPrepare } }
+	} as ReturnType<typeof getCloudflareContext>);
+}
+
 describe('POST /api/prices error responses', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -144,6 +169,12 @@ describe('POST /api/prices payload length', () => {
 
 		expect(response.status).toBe(413);
 	});
+});
+
+describe('POST /api/prices content-type validation', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
 	test('rejects requests without application/json content-type', async () => {
 		const request = new Request('http://localhost/api/prices', {
@@ -168,6 +199,8 @@ describe('POST /api/prices payload length', () => {
 	});
 
 	test('accepts application/json with parameters', async () => {
+		mockDbWithValidResults();
+
 		const request = new Request('http://localhost/api/prices', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json; charset=utf-8' },
@@ -175,6 +208,6 @@ describe('POST /api/prices payload length', () => {
 		});
 		const response = await POST(request);
 
-		expect(response.status).not.toBe(415);
+		expect(response.status).toBe(200);
 	});
 });

--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -33,6 +33,11 @@ function roundToTwo(value: number): number {
 }
 
 export async function POST(request: Request) {
+	const contentType = request.headers.get('content-type') || '';
+	if (!contentType.includes('application/json')) {
+		return NextResponse.json({ error: 'Unsupported Media Type' }, { status: 415 });
+	}
+
 	let requestBody: unknown;
 
 	try {

--- a/app/api/prices/route.ts
+++ b/app/api/prices/route.ts
@@ -34,7 +34,8 @@ function roundToTwo(value: number): number {
 
 export async function POST(request: Request) {
 	const contentType = request.headers.get('content-type') || '';
-	if (!contentType.includes('application/json')) {
+	const mimeType = contentType.split(';')[0].trim().toLowerCase();
+	if (mimeType !== 'application/json') {
 		return NextResponse.json({ error: 'Unsupported Media Type' }, { status: 415 });
 	}
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The API route `/api/prices` parsed request bodies as JSON regardless of the `Content-Type` header. This allowed "Simple Requests" (e.g., `text/plain`, `application/x-www-form-urlencoded` submitted via standard HTML forms) to bypass CORS preflight checks and submit data to the API, exposing the application to simple CSRF and MIME confusion attacks.
🎯 **Impact**: An attacker could trick a user into submitting a cross-origin request to the API, bypassing CORS protections and potentially interacting with the prediction service without authorization.
🔧 **Fix**: Enforced `Content-Type: application/json` validation in the API route, returning a `415 Unsupported Media Type` if the validation fails. Added tests to verify this behavior.
✅ **Verification**: Run `npm run test` to verify that requests without the correct `Content-Type` are rejected with a 415 status code.

---
*PR created automatically by Jules for task [17112849183013051918](https://jules.google.com/task/17112849183013051918) started by @shenghaoc*