### PR TITLE
🎨 Palette: [a11y] fix screen reader unit association on NumberField

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Making Radix UI Tooltip Triggers Keyboard Accessible
 **Learning:** Radix UI `TooltipTrigger` components rely on their children to be natively focusable to trigger tooltips via keyboard navigation. If the `asChild` prop wraps a non-interactive element (like a generic `<div>`), keyboard users cannot access the tooltip content, leading to a critical accessibility failure.
 **Action:** Always ensure that elements wrapped by a `TooltipTrigger` are natively focusable. If wrapping a non-interactive element, explicitly add `tabIndex={0}` and apply clear `focus-visible` styles to provide proper keyboard navigation feedback.
+
+## 2024-05-29 - Number Field Screen Reader Unit Association
+**Learning:** For composite inputs with an `aria-label` and an adjacent visually hidden unit (e.g., a `.sr-only` span), screen readers will ignore the unit text because `aria-label` overrides the element's content, and the sibling unit isn't directly read out in the focus context.
+**Action:** When creating inputs with screen-reader-only unit text, always add an `id` to the unit element and reference it using `aria-describedby` on the input element. This guarantees screen readers announce the full context (e.g., "Floor area, 20, square meters").

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,4 +8,4 @@
 
 ## 2024-05-29 - Number Field Screen Reader Unit Association
 **Learning:** For composite inputs with an `aria-label` and an adjacent visually hidden unit (e.g., a `.sr-only` span), screen readers will ignore the unit text because `aria-label` overrides the element's content, and the sibling unit isn't directly read out in the focus context.
-**Action:** When creating inputs with screen-reader-only unit text, always add an `id` to the unit element and reference it using `aria-describedby` on the input element. This guarantees screen readers announce the full context (e.g., "Floor area, 20, square meters").
+**Action:** When creating inputs with screen-reader-only unit text, always add an `id` to the unit element and reference it using `aria-describedby` on the input element. This guarantees screen readers announce the full context (e.g., "Floor area, 20, square metres"). Keep the screen-reader unit text localizable — pass a translated label into the reusable component (e.g., a `unitLabel` prop) rather than hardcoding an English string, so the announcement matches the active locale.

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -13,6 +13,7 @@
   "switch_to_light_mode": "Switch to light mode",
   "switch_to_dark_mode": "Switch to dark mode",
   "floor_area_unit": "Square metres (m²)",
+  "square_metres": "square metres",
   "switch_language": "中文/English",
   "price_prediction": "Price\nPrediction",
   "intro_blurb": "Compare flat attributes, submit a scenario, and get a quick resale estimate with a 12-month trend view.",

--- a/app/locales/zh.json
+++ b/app/locales/zh.json
@@ -13,6 +13,7 @@
   "switch_to_light_mode": "切换到浅色模式",
   "switch_to_dark_mode": "切换到深色模式",
   "floor_area_unit": "平方米 (m²)",
+  "square_metres": "平方米",
   "switch_language": "中文/English",
   "price_prediction": "价格\n预测",
   "intro_blurb": "比较房屋属性，提交一个情境，并快速查看估算转售价与过去12个月趋势。",

--- a/components/prediction/PredictionForm.tsx
+++ b/components/prediction/PredictionForm.tsx
@@ -133,6 +133,7 @@ export default function PredictionForm({
                 step={5}
                 placeholder={t("enter_floor_area")}
                 unit="m²"
+                unitLabel={t("square_metres")}
                 ariaLabel={t("floor_area")}
                 required
               />

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -13,6 +13,7 @@ type NumberFieldProps = {
   step?: number;
   placeholder?: string;
   unit?: string;
+  unitLabel?: string;
   ariaLabel: string;
   required?: boolean;
   className?: string;
@@ -27,6 +28,7 @@ export function NumberField({
   step = 1,
   placeholder,
   unit,
+  unitLabel,
   ariaLabel,
   required = false,
   className,
@@ -194,7 +196,7 @@ export function NumberField({
       )}
       {/* Accessible unit label for screen readers */}
       {unit && (
-        <span id={`${id}-unit`} className="sr-only">{unit === "m²" ? "square meters" : unit}</span>
+        <span id={`${id}-unit`} className="sr-only">{unitLabel ?? unit}</span>
       )}
 
       {/* Increment */}

--- a/components/ui/number-field.tsx
+++ b/components/ui/number-field.tsx
@@ -170,6 +170,7 @@ export function NumberField({
         required={required}
         aria-required={required}
         aria-label={ariaLabel}
+        aria-describedby={unit ? `${id}-unit` : undefined}
         value={value === "" || value === undefined ? "" : value}
         placeholder={placeholder}
         onChange={handleChange}
@@ -193,7 +194,7 @@ export function NumberField({
       )}
       {/* Accessible unit label for screen readers */}
       {unit && (
-        <span className="sr-only">{unit === "m²" ? "square meters" : unit}</span>
+        <span id={`${id}-unit`} className="sr-only">{unit === "m²" ? "square meters" : unit}</span>
       )}
 
       {/* Increment */}


### PR DESCRIPTION
**💡 What:** Fixed a critical accessibility gap in the `NumberField` component by linking the input to its screen-reader-only unit text using `aria-describedby`.

**🎯 Why:** Previously, screen readers focused on the `NumberField` would only read the `aria-label` (e.g., "Floor area") and the current value, completely skipping the adjacent `.sr-only` unit label (e.g., "square meters"). This left visually impaired users without context on the unit of measurement.

**📸 Before/After:** No visual changes were made; this is a purely semantic, assistive-technology-focused improvement.

**♿ Accessibility:** Screen readers will now correctly announce the full context (e.g., "Floor area, 20, square meters") instead of just "Floor area, 20".

---
*PR created automatically by Jules for task [50829586280711716](https://jules.google.com/task/50829586280711716) started by @shenghaoc*