### PR TITLE
fix: improve mobile and desktop accessibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -96,10 +96,14 @@
   color-scheme: dark;
 }
 
-/* Touch-target accessibility: raise interactive element height on mobile */
-@media (max-width: 640px) {
+/* Touch-target accessibility: raise interactive element heights on mobile.
+   Uses width < 640px (range syntax) to match Tailwind v4's max-sm: breakpoint exactly. */
+@media (width < 640px) {
   :root {
     --height-field: 44px;
+    --height-button: 44px;
+    --height-button-sm: 44px;
+    --height-icon-button: 44px;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,6 +96,13 @@
   color-scheme: dark;
 }
 
+/* Touch-target accessibility: raise interactive element height on mobile */
+@media (max-width: 640px) {
+  :root {
+    --height-field: 44px;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Source_Sans_3 } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
 import { cookies } from 'next/headers';
@@ -22,6 +22,11 @@ const sourceSans3 = Source_Sans_3({
 	variable: '--font-source-sans',
 	display: 'swap'
 });
+
+export const viewport: Viewport = {
+	width: 'device-width',
+	initialScale: 1,
+};
 
 export const metadata: Metadata = {
 	title: {

--- a/app/styles.css
+++ b/app/styles.css
@@ -258,7 +258,7 @@ html {
   input,
   select,
   textarea {
-    font-size: 1rem;
+    font-size: 16px;
   }
 }
 

--- a/app/styles.css
+++ b/app/styles.css
@@ -254,7 +254,7 @@ html {
 /* ── iOS auto-zoom prevention ─────────────────────────────────────────── */
 /* iOS Safari zooms in when a focused input has font-size < 16px.
    This override ensures inputs are at least 16px on touch screens. */
-@media (max-width: 640px) {
+@media (width < 640px) {
   input,
   select,
   textarea {

--- a/app/styles.css
+++ b/app/styles.css
@@ -251,6 +251,17 @@ html {
     0 12px 28px color-mix(in oklab, var(--foreground) 10%, transparent);
 }
 
+/* ── iOS auto-zoom prevention ─────────────────────────────────────────── */
+/* iOS Safari zooms in when a focused input has font-size < 16px.
+   This override ensures inputs are at least 16px on touch screens. */
+@media (max-width: 640px) {
+  input,
+  select,
+  textarea {
+    font-size: 1rem;
+  }
+}
+
 /* ── No-spinner inputs ────────────────────────────────────────────────── */
 input[data-no-spinner="true"]::-webkit-outer-spin-button,
 input[data-no-spinner="true"]::-webkit-inner-spin-button {

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -258,7 +258,7 @@ export default function PredictionClient() {
             </Badge>
           </div>
 
-          <div className="flex items-center gap-2 max-sm:w-full max-sm:[&>*]:flex-1">
+          <div className="flex items-center gap-2 max-sm:w-full">
             <Button
               type="button"
               variant="outline"
@@ -278,6 +278,7 @@ export default function PredictionClient() {
                   type="button"
                   variant="outline"
                   size="icon-sm"
+                  className="max-sm:h-11 max-sm:w-11"
                   aria-label={isDark ? t("switch_to_light_mode") : t("switch_to_dark_mode")}
                   onClick={toggleTheme}
                 >

--- a/components/prediction/PredictionClient.tsx
+++ b/components/prediction/PredictionClient.tsx
@@ -263,7 +263,7 @@ export default function PredictionClient() {
               type="button"
               variant="outline"
               size="sm"
-              className="normal-case tracking-normal max-sm:flex-1"
+              className="normal-case tracking-normal max-sm:flex-1 max-sm:h-11"
               onClick={() => {
                 startTransition(() => {
                   changeLang(lang === "en" ? "zh" : "en");

--- a/components/prediction/PredictionResults.tsx
+++ b/components/prediction/PredictionResults.tsx
@@ -243,14 +243,14 @@ function StatChip({
       <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">{label}</p>
       <p
         className={cn(
-          "mt-1 flex items-center gap-1 text-sm font-semibold tabular-nums",
+          "mt-1 flex min-w-0 flex-wrap items-center gap-1 text-sm font-semibold tabular-nums",
           trend === "up" && "text-emerald-600 dark:text-emerald-400",
           trend === "down" && "text-amber-700 dark:text-amber-400",
           !trend && "text-foreground",
         )}
       >
         {TrendIcon && <TrendIcon className="size-3.5 shrink-0" aria-hidden />}
-        {value}
+        <span className="break-words">{value}</span>
       </p>
       {hint && (
         <p className="mt-0.5 text-[9px] font-bold uppercase tracking-wider text-muted-foreground">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Viewport meta**: Add explicit `viewport` export to `layout.tsx` (`width=device-width, initialScale=1`) so browsers render at native device width instead of a scaled-down desktop view
- **Touch targets**: Raise `--height-field` from 32 px to 44 px on mobile (≤640 px) so all form inputs, combobox, and number-field steppers meet the WCAG 2.5.5 minimum touch-target size
- **iOS auto-zoom**: Set `font-size: 1rem` on `input / select / textarea` on mobile — iOS Safari zooms in when a focused input has `font-size < 16 px`, which disrupts the layout
- **Header icon button**: Remove `max-sm:[&>*]:flex-1` that incorrectly stretched the theme-toggle icon button to half the screen width; give it an explicit `44 × 44 px` touch target on mobile (`max-sm:h-11 max-sm:w-11`) while the language button stays `flex-1`
- **StatChip overflow**: Add `min-w-0 flex-wrap` and wrap the value in a `break-words` span so long currency ranges like `SGD 100,000 – SGD 500,000` wrap instead of overflowing the chip on narrow viewports

## Test plan

- [ ] Open on a real iOS device (or Chrome DevTools mobile emulation) and confirm inputs no longer auto-zoom on focus
- [ ] Verify all form inputs are ≥44 px tall on mobile
- [ ] Verify the theme-toggle button is 44 × 44 px on mobile and the language button fills remaining width
- [ ] Trigger a prediction and confirm the StatChip range value wraps cleanly on narrow screens
- [ ] Confirm desktop layout is unchanged (all changes are scoped to `max-width: 640px` or are additive)
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqCcvKWqJW9bsW6MQ8AKnr)_